### PR TITLE
Clnt-6: Fix versioning, deploy to test PyPI / PyPI and docs deployments

### DIFF
--- a/.github/workflows/deploy-to-pypi.yaml
+++ b/.github/workflows/deploy-to-pypi.yaml
@@ -1,15 +1,27 @@
-name: Push package to PyPI
+name: Release new version of package and push package to PyPI
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release. Must be a valid version number; x is forbidden'
+        required: true
+        default: '0.1.x'
+      message:
+        description: 'Message to attach to the release'
+        required: false
+        default: "Release notes \n"
+      test:
+        description: 'Release beta release to test PyPI'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   push_to_testpypi:
     name: Upload release to test PyPI
-    if: ${{ github.event_name == 'push' && contains(github.ref, 'b') }}
     runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.test == true && github.event.inputs.version != '0.1.x' && contains(github.event.inputs.version, 'b') }}
     environment:
       name: testpypi
       url: https://test.pypi.org/p/hirundo
@@ -18,11 +30,24 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: 'pip'
+      - name: Bump version with `bumpver` then push tag
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install bumpver
+          git config user.name "GitHub Actions [release-bot]"
+          git config user.email "devs@hirundo.io"
+          bumpver update --set-version ${{ github.event.inputs.version }} --commit --push
+          git tag -a v${{ github.event.inputs.version }} -m "${{ github.event.inputs.message }}"
+          git push origin v${{ github.event.inputs.version }}
       - name: Install dependencies & build package
         run: |
           python -m pip install --upgrade pip
@@ -35,9 +60,16 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Save version to artifact
+        run: echo "${{ github.event.inputs.version }}" > version.txt
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: version
+          path: version.txt
   push_to_pypi:
     name: Upload release to PyPI
-    if: ${{ github.event_name == 'push' && !contains(github.ref, 'b') }}
+    if: ${{ github.event.inputs.test == false && github.event.inputs.version != '0.1.x' && !contains(github.event.inputs.version, 'b') }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -47,11 +79,24 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: 'pip'
+      - name: Bump version with `bumpver` then push tag
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install bumpver
+          git config user.name "GitHub Actions [release-bot]"
+          git config user.email "devs@hirundo.io"
+          bumpver update --set-version ${{ github.event.inputs.version }} --commit --push
+          git tag -a v${{ github.event.inputs.version }} -m "${{ github.event.inputs.message }}"
+          git push origin v${{ github.event.inputs.version }}
       - name: Install dependencies & build package
         run: |
           python -m pip install --upgrade pip
@@ -62,3 +107,10 @@ jobs:
           python -m build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Save version to artifact
+        run: echo "${{ github.event.inputs.version }}" > version.txt
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: version
+          path: version.txt

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -1,12 +1,10 @@
 name: Deploy Sphinx docs to GitHub Pages
 
 on:
-    push:
-        branches: ["main"]
-        tags:
-          - "v*"
-    pull_request:
-        types: [opened, synchronize, reopened]
+    workflow_run:
+        workflows: ["Release new version of package and push package to PyPI"]
+        types:
+            - completed
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -22,16 +20,24 @@ concurrency:
 
 jobs:
     deploy-docs:
-        if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'update-docs')}}
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
         runs-on: ubuntu-latest
         steps:
+        - name: Download version artifact
+          uses: actions/download-artifact@v3
+          with:
+            name: version
+        - name: Read input from artifact
+          id: read_version
+          run: |
+            version=$(cat version.txt)
+            echo "::set-output name=version::${version}"
         - name: Checkout
           uses: actions/checkout@v4
           with:
-            ref: ${{ github.head_ref }}
+            ref: v${{ steps.read_version.outputs.version }}
             fetch-depth: 0  # Fetch all history for all tags and branches
         - uses: actions/setup-python@v3
           with:
@@ -42,7 +48,8 @@ jobs:
             python -m venv .venv
             source .venv/bin/activate
             pip install -r docs-requirements.txt
-            pip install hirundo
+            export VERSION=${{ steps.read_version.outputs.version }}
+            pip install hirundo@${VERSION}
         - name: Sphinx multi-version build
           run: |
             source .venv/bin/activate


### PR DESCRIPTION
This means that versioning is automated by GitHub Actions pipeline which pushes a commit and tag Previous approach did not work, since tags pushed to development branches broke ability to push the same tag afterwards, and thus `bumpver` in PRs with git tag could break releases from `main` afterwards