### PR TITLE
Clnt-51: Fix tests by first cancelling runs before deleting datasets

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -51,4 +51,4 @@ jobs:
           git push -u origin release-${{ github.event.inputs.version }}
           gh pr create -a ${{ github.event.sender }} --title "v${{ github.event.inputs.version }}" \
             --body "${{ github.event.inputs.message }}" \
-            --label "${{ github.event.inputs.test && 'test' || 'release' }}"
+            --label "${{ github.event.inputs.test == 'true' && 'test' || 'release' }}"

--- a/hirundo/dataset_optimization.py
+++ b/hirundo/dataset_optimization.py
@@ -764,6 +764,32 @@ class OptimizationDataset(BaseModel):
             raise ValueError("No run has been started")
         self.cancel_by_id(self.run_id)
 
+    @staticmethod
+    def archive_run_by_id(run_id: str) -> None:
+        """
+        Archive the dataset optimization run for the given `run_id`.
+
+        Args:
+            run_id: The ID of the run to archive
+        """
+        if not run_id:
+            raise ValueError("No run has been started")
+        logger.info("Archiving run with ID: %s", run_id)
+        response = requests.patch(
+            f"{API_HOST}/dataset-optimization/run/archive/{run_id}",
+            headers=get_headers(),
+            timeout=MODIFY_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+
+    def archive(self) -> None:
+        """
+        Archive the current active instance's run.
+        """
+        if not self.run_id:
+            raise ValueError("No run has been started")
+        self.archive_run_by_id(self.run_id)
+
 
 class DataOptimizationDatasetOut(BaseModel):
     id: int

--- a/hirundo/dataset_optimization.py
+++ b/hirundo/dataset_optimization.py
@@ -551,7 +551,9 @@ class OptimizationDataset(BaseModel):
                 f"Optimization run failed with error: {iteration['result']}"
             )
         else:
-            raise HirundoError("Optimization run failed with an unknown error")
+            raise HirundoError(
+                "Optimization run failed with an unknown error in _handle_failure"
+            )
 
     @staticmethod
     @overload
@@ -602,6 +604,9 @@ class OptimizationDataset(BaseModel):
                         RunStatus.REJECTED.value,
                         RunStatus.REVOKED.value,
                     ]:
+                        logger.error(
+                            "State is failure, rejected, or revoked", iteration["state"]
+                        )
                         OptimizationDataset._handle_failure(iteration)
                     elif iteration["state"] == RunStatus.SUCCESS.value:
                         t.close()
@@ -646,7 +651,9 @@ class OptimizationDataset(BaseModel):
                         t.n = current_progress_percentage
                         logger.debug("Setting progress to %s", t.n)
                         t.refresh()
-        raise HirundoError("Optimization run failed with an unknown error")
+        raise HirundoError(
+            "Optimization run failed with an unknown error in check_run_by_id"
+        )
 
     @overload
     def check_run(

--- a/hirundo/dataset_optimization.py
+++ b/hirundo/dataset_optimization.py
@@ -605,7 +605,8 @@ class OptimizationDataset(BaseModel):
                         RunStatus.REVOKED.value,
                     ]:
                         logger.error(
-                            "State is failure, rejected, or revoked", iteration["state"]
+                            "State is failure, rejected, or revoked: %s",
+                            iteration["state"],
                         )
                         OptimizationDataset._handle_failure(iteration)
                     elif iteration["state"] == RunStatus.SUCCESS.value:

--- a/tests/dataset_optimization_shared.py
+++ b/tests/dataset_optimization_shared.py
@@ -104,9 +104,7 @@ def cleanup(test_dataset: OptimizationDataset):
         runs_by_dataset = {
             run.dataset_id: [run.run_id]
             for run in runs
-            if run.dataset_id is not None
-            and run.run_id is not None
-            and run.status == RunStatus.STARTED
+            if run.dataset_id is not None and run.run_id is not None
         }
         if dataset.id is not None:
             logger.debug(

--- a/tests/dataset_optimization_shared.py
+++ b/tests/dataset_optimization_shared.py
@@ -93,6 +93,17 @@ def _handle_not_found_error(dataset: OptimizationDataset):
             raise e
 
 
+def _get_runs_by_dataset():
+    runs = OptimizationDataset.list_runs()
+    runs_by_dataset = {}
+    for run in runs:
+        if run.dataset_id is not None and run.run_id is not None:
+            if run.dataset_id not in runs_by_dataset:
+                runs_by_dataset[run.dataset_id] = []
+            runs_by_dataset[run.dataset_id].append(run.run_id)
+    return runs_by_dataset
+
+
 def cleanup(test_dataset: OptimizationDataset):
     logger.info("Started cleanup")
     with _handle_not_found_error(test_dataset):
@@ -100,12 +111,7 @@ def cleanup(test_dataset: OptimizationDataset):
         storage_config_id = (
             dataset.storage_config.id if dataset.storage_config is not None else None
         )
-        runs = OptimizationDataset.list_runs()
-        runs_by_dataset = {
-            run.dataset_id: [run.run_id]
-            for run in runs
-            if run.dataset_id is not None and run.run_id is not None
-        }
+        runs_by_dataset = _get_runs_by_dataset()
         if dataset.id is not None:
             logger.debug(
                 "Found optimization dataset with the same name, deleting it",

--- a/tests/dataset_optimization_shared.py
+++ b/tests/dataset_optimization_shared.py
@@ -130,12 +130,10 @@ def cleanup(test_dataset: OptimizationDataset):
                     e,
                 )
         if dataset.storage_config is not None:
-            storage_config = test_dataset.storage_config
-            if storage_config is None or storage_config.id is None:
-                raise ValueError(
-                    "Storage config ID is not None, this should not happen"
-                )
-            storage_config_id = storage_config.id
+            storage_config = dataset.storage_config
+            storage_config_id = dataset.storage_config_id
+            if storage_config_id is None:
+                raise ValueError("Storage config ID is None, this should not happen")
             logger.debug(
                 "Found storage config with ID %s, deleting it", storage_config_id
             )

--- a/tests/dataset_optimization_shared.py
+++ b/tests/dataset_optimization_shared.py
@@ -129,11 +129,9 @@ def cleanup(test_dataset: OptimizationDataset):
                     dataset.id,
                     e,
                 )
-        if dataset.storage_config is not None:
+        if dataset.storage_config is not None and dataset.storage_config_id is not None:
             storage_config = dataset.storage_config
             storage_config_id = dataset.storage_config_id
-            if storage_config_id is None:
-                raise ValueError("Storage config ID is None, this should not happen")
             logger.debug(
                 "Found storage config with ID %s, deleting it", storage_config_id
             )

--- a/tests/dataset_optimization_shared.py
+++ b/tests/dataset_optimization_shared.py
@@ -6,7 +6,6 @@ from hirundo import (
     OptimizationDataset,
     RunArgs,
     StorageConfig,
-    StorageTypes,
 )
 from hirundo.dataset_optimization import RunStatus
 from hirundo.logger import get_logger
@@ -20,35 +19,54 @@ def get_unique_id():
     )
 
 
-def log_cleanup(storage_config_ids: list[int], git_repo_ids: list[int]):
-    if len(storage_config_ids) > 0:
-        logger.debug("Found %s storage configs, deleting them", len(storage_config_ids))
-        logger.debug("Note: If I am not the owner, I will not be able to delete them")
-    if len(git_repo_ids) > 0:
-        logger.debug("Found %s git repos, deleting them", len(git_repo_ids))
-        logger.debug("Note: If I am not the owner, I will not be able to delete them")
+def log_cleanup(
+    storage_config_id: typing.Optional[int], git_repo_id: typing.Optional[int]
+):
+    if storage_config_id is not None:
+        logger.debug("Found storage config with ID %s, deleting it", storage_config_id)
+        logger.debug("Note: If I am not the owner, I will not be able to delete it")
+    if git_repo_id is not None:
+        logger.debug("Found git repo with ID %s, deleting it", git_repo_id)
+        logger.debug("Note: If I am not the owner, I will not be able to delete it")
 
 
 def cleanup_conflict_by_unique_id(unique_id: typing.Optional[str]):
     if not unique_id:
         return
+    conflicting_runs = OptimizationDataset.list_runs()
+    conflicting_run_ids = [
+        run.run_id for run in conflicting_runs if unique_id in run.name
+    ]
+    conflicting_datasets = OptimizationDataset.list_datasets()
+    conflicting_dataset_ids = [
+        dataset.id for dataset in conflicting_datasets if unique_id in dataset.name
+    ]
     conflicting_git_repo_ids = [
         git_repo.id for git_repo in GitRepo.list() if unique_id in git_repo.name
     ]
-    for conflicting_git_repo_id in conflicting_git_repo_ids:
-        try:
-            GitRepo.delete_by_id(conflicting_git_repo_id)
-        except Exception as e:
-            logger.warning(
-                "Failed to delete git repo with ID %s and exception %s",
-                conflicting_git_repo_id,
-                e,
-            )
     conflicting_storage_config_ids = [
         storage_config.id
         for storage_config in StorageConfig.list()
         if unique_id in storage_config.name and storage_config.id is not None
     ]
+    for conflicting_run_id in conflicting_run_ids:
+        try:
+            OptimizationDataset.archive_run_by_id(conflicting_run_id)
+        except Exception as e:
+            logger.warning(
+                "Failed to archive run with ID %s and exception %s",
+                conflicting_run_id,
+                e,
+            )
+    for conflicting_dataset_id in conflicting_dataset_ids:
+        try:
+            OptimizationDataset.delete_by_id(conflicting_dataset_id)
+        except Exception as e:
+            logger.warning(
+                "Failed to delete dataset with ID %s and exception %s",
+                conflicting_dataset_id,
+                e,
+            )
     for conflicting_storage_config_id in conflicting_storage_config_ids:
         try:
             StorageConfig.delete_by_id(conflicting_storage_config_id)
@@ -58,69 +76,65 @@ def cleanup_conflict_by_unique_id(unique_id: typing.Optional[str]):
                 conflicting_storage_config_id,
                 e,
             )
+    for conflicting_git_repo_id in conflicting_git_repo_ids:
+        try:
+            GitRepo.delete_by_id(conflicting_git_repo_id)
+        except Exception as e:
+            logger.warning(
+                "Failed to delete git repo with ID %s and exception %s",
+                conflicting_git_repo_id,
+                e,
+            )
 
 
 def cleanup(test_dataset: OptimizationDataset):
     logger.info("Started cleanup")
-    datasets = OptimizationDataset.list_datasets()
-    dataset_ids = [
-        dataset.id
-        for dataset in datasets
-        if dataset.name == test_dataset.name and dataset.id
-    ]
-    storage_config_ids = [
-        dataset.storage_config.id
-        for dataset in datasets
-        if dataset.name == test_dataset.name and dataset.storage_config.id is not None
-    ]
+    dataset = OptimizationDataset.get_by_name(test_dataset.name)
+    storage_config_id = (
+        dataset.storage_config.id if dataset.storage_config is not None else None
+    )
     runs = OptimizationDataset.list_runs()
-    running_datasets = {
-        run.id: run.run_id
+    runs_by_dataset = {
+        run.dataset_id: [run.run_id]
         for run in runs
-        if (
-            run.name == test_dataset.name
-            and run.run_id is not None
-            and run.status == RunStatus.STARTED
-        )
+        if run.dataset_id is not None
+        and run.run_id is not None
+        and run.status == RunStatus.STARTED
     }
-    if len(dataset_ids) > 0:
+    if dataset.id is not None:
         logger.debug(
-            "Found %s optimization datasets with the same name, deleting them",
-            len(dataset_ids),
+            "Found optimization dataset with the same name, deleting it",
         )
         logger.debug("Note: If I am not the owner, I will not be able to delete them")
-    for dataset_id in dataset_ids:
         try:
-            if dataset_id in running_datasets:
-                run_id = running_datasets[dataset_id]
-                logger.debug("Cancelling optimization dataset with run ID %s", run_id)
-                OptimizationDataset.cancel_by_id(run_id)
-            OptimizationDataset.delete_by_id(dataset_id)
+            if dataset.id in runs_by_dataset:
+                for run_id in runs_by_dataset[dataset.id]:
+                    logger.debug(
+                        "Archiving optimization dataset with run ID %s", run_id
+                    )
+                    OptimizationDataset.archive_run_by_id(run_id)
+            OptimizationDataset.delete_by_id(dataset.id)
         except Exception as e:
             logger.warning(
                 "Unable to delete optimization dataset with ID %s and exception %s",
-                dataset_id,
+                dataset.id,
                 e,
             )
-    storage_configs = StorageConfig.list()
-    storage_config_ids = (
-        [
-            storage_config.id
-            for storage_config in storage_configs
-            if storage_config.name == test_dataset.storage_config.name
-        ]
-        if (test_dataset.storage_config is not None)
-        else storage_config_ids
-    )  # ⬆️ If given a StorageConfig object, use it's name to find the matching IDs
-    git_repo_ids = [
-        storage_config.git.repo.id
-        for storage_config in storage_configs
-        if storage_config.type == StorageTypes.GIT
-        and storage_config.git is not None
-        and storage_config.id in storage_config_ids
-    ]
-    log_cleanup(storage_config_ids, git_repo_ids)
-    for storage_config_id in storage_config_ids:
+    storage_config = (
+        StorageConfig.get_by_name(
+            test_dataset.storage_config.name,
+            test_dataset.storage_config.type,
+        )
+        if test_dataset.storage_config is not None
+        and test_dataset.storage_config.type is not None
+        else None
+    )
+    if storage_config is not None:
+        storage_config_id = storage_config.id
+        git_repo_id = (
+            storage_config.git.repo.id if storage_config.git is not None else None
+        )
+        log_cleanup(storage_config_id, git_repo_id)
         try:
             StorageConfig.delete_by_id(storage_config_id)
         except Exception as e:
@@ -129,15 +143,15 @@ def cleanup(test_dataset: OptimizationDataset):
                 storage_config_id,
                 e,
             )
-    for git_repo_id in git_repo_ids:
-        try:
-            GitRepo.delete_by_id(git_repo_id)
-        except Exception as e:
-            logger.warning(
-                "Unable to delete git repo with ID %s and exception %s",
-                git_repo_id,
-                e,
-            )
+        if git_repo_id is not None:
+            try:
+                GitRepo.delete_by_id(git_repo_id)
+            except Exception as e:
+                logger.warning(
+                    "Unable to delete git repo with ID %s and exception %s",
+                    git_repo_id,
+                    e,
+                )
     # ⬆️ Delete all datasets and storage configs from the server for the given user's default organization
     test_dataset.clean_ids()
     # ⬆️ Reset `dataset_id`, `storage_config_id`, and `run_id` values on `test_dataset` to default value of `None`


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances dataset optimization by adding a function to organize runs by dataset, improving error handling and logging. It ensures only valid repository and run IDs are processed, increasing the reliability of cleanup operations and clarifying logging for failure states, aiding in issue diagnosis.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>