### PR TITLE
feature/Clnt-57-cleanup-test-artifacts

### DIFF
--- a/.github/event_cleanup_test.json
+++ b/.github/event_cleanup_test.json
@@ -1,0 +1,1 @@
+{"workflow_dispatch": {}}

--- a/.github/workflows/cleanup-test-artifacts.yaml
+++ b/.github/workflows/cleanup-test-artifacts.yaml
@@ -1,0 +1,31 @@
+name: Clean up test datasets
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv venv
+          uv pip install -r requirements/requirements.txt
+      - name: Run cleanup script
+        run: .venv/bin/python scripts/cleanup_test_artifacts.py
+        env:
+          API_HOST: ${{ secrets.API_HOST }}
+          API_KEY: ${{ secrets.API_KEY }}

--- a/scripts/cleanup_test_artifacts.py
+++ b/scripts/cleanup_test_artifacts.py
@@ -1,0 +1,93 @@
+import datetime
+from collections import defaultdict
+from datetime import timedelta, timezone
+from typing import Optional, Union
+
+import requests
+from hirundo import GitRepo, OptimizationDataset, StorageConfig
+from hirundo.dataset_optimization import HirundoError, RunStatus
+from hirundo.logger import get_logger
+from hirundo.storage import ResponseStorageConfig
+
+logger = get_logger(__name__)
+
+
+def _delete_dataset(
+    dataset_id: int,
+    storage_config: Optional[Union[StorageConfig, ResponseStorageConfig]],
+) -> None:
+    try:
+        OptimizationDataset.delete_by_id(dataset_id)
+    except (HirundoError, requests.HTTPError) as exc:
+        logger.warning("Failed to delete dataset with ID %s: %s", dataset_id, exc)
+
+    if storage_config and storage_config.id is not None:
+        try:
+            StorageConfig.delete_by_id(storage_config.id)
+        except (HirundoError, requests.HTTPError) as exc:
+            logger.warning(
+                "Failed to delete storage config with ID %s: %s", storage_config.id, exc
+            )
+
+        if (
+            storage_config.git is not None
+            and storage_config.git.repo is not None
+            and storage_config.git.repo.id is not None
+        ):
+            git_repo_id = storage_config.git.repo.id
+            try:
+                GitRepo.delete_by_id(git_repo_id)
+            except (HirundoError, requests.HTTPError) as exc:
+                logger.warning(
+                    "Failed to delete git repo with ID %s: %s", git_repo_id, exc
+                )
+
+
+def _should_delete_dataset(dataset_runs: list, expiry_date: datetime.datetime) -> bool:
+    """Return ``True`` if the dataset should be deleted."""
+
+    if not dataset_runs:
+        return False
+
+    if all(run.status == RunStatus.SUCCESS for run in dataset_runs):
+        return True
+
+    most_recent_run_time = max(run.created_at for run in dataset_runs)
+    return most_recent_run_time <= expiry_date
+
+
+def main() -> None:
+    all_runs = OptimizationDataset.list_runs()
+    datasets = {
+        dataset_entry.id: dataset_entry
+        for dataset_entry in OptimizationDataset.list_datasets()
+        if dataset_entry.id is not None
+    }
+    now = datetime.datetime.now(timezone.utc)
+    one_week_ago = now - timedelta(days=7)
+
+    runs_by_dataset: defaultdict[int, list] = defaultdict(list)
+    for run in all_runs:
+        if run.dataset_id is None or run.run_id is None:
+            continue
+        runs_by_dataset[run.dataset_id].append(run)
+
+    for dataset_id, dataset_runs in runs_by_dataset.items():
+        dataset = datasets.get(dataset_id)
+        if dataset is None or not dataset.name.startswith("TEST-"):
+            continue
+
+        if _should_delete_dataset(dataset_runs, one_week_ago):
+            for run in dataset_runs:
+                try:
+                    OptimizationDataset.archive_run_by_id(run.run_id)
+                except (HirundoError, requests.HTTPError) as exc:
+                    logger.warning(
+                        "Failed to archive run with ID %s: %s", run.run_id, exc
+                    )
+
+            _delete_dataset(dataset_id, dataset.storage_config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add event JSON for testing workflow with `act`
- fix type annotation for `_delete_dataset`
- ensure cleanup workflow can be tested locally

## Testing
- `ruff check scripts/cleanup_test_artifacts.py`
- `pyright scripts/cleanup_test_artifacts.py --pythonversion 3.12`
- `pytest -k 'dummy'` *(fails: ModuleNotFoundError for httpx)*
- `act -n -W .github/workflows/cleanup-test-artifacts.yaml -e .github/event_cleanup_test.json` *(prompted for container image then exited)*

------
https://chatgpt.com/codex/tasks/task_b_684ad87468ec8331845756e62d9db33d 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new scheduled GitHub Actions workflow for weekly cleanup of test datasets, along with a Python script to check and delete expired datasets and their configurations. These changes enhance the management of test artifacts, optimizing storage usage.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>