### PR TITLE
chore: bump authlib to 1.6.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "virtualenv>=20.6.6",
     #  ⬆️ Needed for `pre-commit` and locking version for `safety-cli`
     #  version fixes vulnerability GHSA-rqc4-2hc7-8c8v
+    "authlib>=1.6.5",
     "ruff>=0.12.0",
     "bumpver",
     "platformdirs>=4.3.6",

--- a/uv.lock
+++ b/uv.lock
@@ -63,14 +63,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.1"
+version = "1.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/a1/d8d1c6f8bc922c0b87ae0d933a8ed57be1bef6970894ed79c2852a153cd3/authlib-1.6.1.tar.gz", hash = "sha256:4dffdbb1460ba6ec8c17981a4c67af7d8af131231b5a36a88a1e8c80c111cdfd", size = 159988 }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/3f/1d3bbd0bf23bdd99276d4def22f29c27a914067b4cf66f753ff9b8bbd0f3/authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b", size = 164553 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/58/cc6a08053f822f98f334d38a27687b69c6655fb05cd74a7a5e70a2aeed95/authlib-1.6.1-py2.py3-none-any.whl", hash = "sha256:e9d2031c34c6309373ab845afc24168fe9e93dc52d252631f52642f21f5ed06e", size = 239299 },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/5082412d1ee302e9e7d80b6949bc4d2a8fa1149aaab610c5fc24709605d6/authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a", size = 243608 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add an explicit dev extra constraint requiring authlib 1.6.5
- update the uv lockfile entry for authlib to match the new release metadata

## Testing
- uv run --extra dev pytest *(fails: missing AWS_ACCESS_KEY, GCP_CREDENTIALS, and HUGGINGFACE_ACCESS_TOKEN environment variables required by integration tests)*
- uv run --extra dev ruff check
- uv run --python 3.11 --extra dev pyright *(fails: unable to download the requested python-build-standalone artifact in this environment)*
- uv run --python 3.10 --extra dev pyright *(fails: unable to download the requested python-build-standalone artifact in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ece2429e788331a34aeb69bad4c728

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `authlib>=1.6.5` to the `dev` extra and updates `uv.lock` to Authlib 1.6.5 metadata.
> 
> - **Dependencies**:
>   - **Dev extra**: Add `authlib>=1.6.5` in `pyproject.toml` under `[project.optional-dependencies].dev`.
>   - **Lockfile**: Update `uv.lock` entry for `authlib` from `1.6.1` to `1.6.5` (sdist/wheel URLs, hashes, sizes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51d1137f888fd05a36d2d75ffe9ea5d26bf17210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->