### PR TITLE
SDK-43: Add LLM unlearning support

### DIFF
--- a/hirundo/__init__.py
+++ b/hirundo/__init__.py
@@ -23,6 +23,15 @@ from .labeling import (
     KeylabsObjSegImages,
     KeylabsObjSegVideo,
 )
+from .llm import (
+    BiasRunInfo,
+    BiasType,
+    HuggingFaceTransformersModel,
+    LlmModel,
+    LlmUnlearningData,
+    LlmUnlearningRun,
+    UnlearningExample,
+)
 from .storage import (
     StorageConfig,
     StorageGCP,
@@ -61,6 +70,13 @@ __all__ = [
     "DatasetQAResults",
     "load_df",
     "load_from_zip",
+    "HuggingFaceTransformersModel",
+    "LlmModel",
+    "LlmUnlearningRun",
+    "BiasRunInfo",
+    "BiasType",
+    "LlmUnlearningData",
+    "UnlearningExample",
 ]
 
 __version__ = "0.1.21"

--- a/hirundo/llm.py
+++ b/hirundo/llm.py
@@ -1,0 +1,266 @@
+"""Utilities for interacting with Hirundo large language model APIs."""
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from hirundo._env import API_HOST
+from hirundo._headers import get_headers
+from hirundo._http import raise_for_status_with_reason, requests
+from hirundo._timeouts import MODIFY_TIMEOUT, READ_TIMEOUT
+
+
+class BiasType(StrEnum):
+    """Types of bias mitigations supported by the Hirundo API."""
+
+    ALL = "ALL"
+    HATE_SPEECH = "HATE_SPEECH"
+    SEXUAL_CONTENT = "SEXUAL_CONTENT"
+    HARASSMENT = "HARASSMENT"
+    SELF_HARM = "SELF_HARM"
+    VIOLENCE = "VIOLENCE"
+    OTHER = "OTHER"
+
+
+class BiasRunInfo(BaseModel):
+    """Configuration for an unlearning bias mitigation run."""
+
+    bias_type: BiasType | str
+    unlearning_data_ids: list[int] | None = None
+    metadata: dict[str, Any] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize the run information for use in HTTP requests."""
+
+        return self.model_dump(mode="json", exclude_none=True)
+
+
+class HuggingFaceTransformersModel(BaseModel):
+    """A Hugging Face transformers model source."""
+
+    source_type: str = Field(
+        default="HUGGING_FACE_TRANSFORMERS",
+        validation_alias="model_source_type",
+        serialization_alias="model_source_type",
+    )
+    model_name: str
+    token: str
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class LlmModel(BaseModel):
+    """Representation of an LLM managed through Hirundo."""
+
+    id: int | None = None
+    model_name: str
+    model_source: HuggingFaceTransformersModel
+    description: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    def create(
+        self,
+        organization_id: int | None = None,
+        replace_if_exists: bool = False,
+    ) -> int:
+        """Create the LLM model on the Hirundo server."""
+
+        payload = self.model_dump(mode="json", by_alias=True, exclude_none=True)
+        payload.pop("id", None)
+        if organization_id is not None:
+            payload["organization_id"] = organization_id
+        if replace_if_exists:
+            payload["replace_if_exists"] = replace_if_exists
+
+        response = requests.post(
+            f"{API_HOST}/llm/model/",
+            json=payload,
+            headers=get_headers(),
+            timeout=MODIFY_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+        response_json = response.json()
+        self.id = response_json.get("id")
+        if self.id is None:
+            raise ValueError("Server response did not include a model ID")
+        return self.id
+
+    @staticmethod
+    def get_by_id(model_id: int) -> LlmModel:
+        """Fetch an existing LLM model from the Hirundo server."""
+
+        response = requests.get(
+            f"{API_HOST}/llm/model/{model_id}",
+            headers=get_headers(),
+            timeout=READ_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+        return LlmModel(**response.json())
+
+    @staticmethod
+    def list_models(organization_id: int | None = None) -> list[LlmModel]:
+        """List LLM models available to the authenticated organization."""
+
+        response = requests.get(
+            f"{API_HOST}/llm/model/",
+            headers=get_headers(),
+            timeout=READ_TIMEOUT,
+            params={"organization_id": organization_id} if organization_id else None,
+        )
+        raise_for_status_with_reason(response)
+        return [LlmModel(**model_json) for model_json in response.json()]
+
+    @staticmethod
+    def delete_by_id(model_id: int) -> None:
+        """Delete an existing LLM model from the Hirundo server."""
+
+        response = requests.delete(
+            f"{API_HOST}/llm/model/{model_id}",
+            headers=get_headers(),
+            timeout=MODIFY_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+
+    def delete(self) -> None:
+        """Delete the model represented by this instance."""
+
+        if self.id is None:
+            raise ValueError("Model must have an ID before it can be deleted")
+        self.delete_by_id(self.id)
+
+
+class UnlearningExample(BaseModel):
+    """An individual example used for LLM unlearning."""
+
+    prompt: str
+    completion: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class LlmUnlearningData(BaseModel):
+    """A dataset containing examples for LLM unlearning."""
+
+    id: int | None = None
+    name: str
+    description: str | None = None
+    examples: list[UnlearningExample]
+    tags: list[str] | None = None
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    def create(
+        self,
+        organization_id: int | None = None,
+        replace_if_exists: bool = False,
+    ) -> int:
+        """Create the unlearning dataset on the Hirundo server."""
+
+        payload = self.model_dump(mode="json", by_alias=True, exclude_none=True)
+        payload.pop("id", None)
+        if organization_id is not None:
+            payload["organization_id"] = organization_id
+        if replace_if_exists:
+            payload["replace_if_exists"] = replace_if_exists
+
+        response = requests.post(
+            f"{API_HOST}/llm/unlearning-data/",
+            json=payload,
+            headers=get_headers(),
+            timeout=MODIFY_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+        response_json = response.json()
+        self.id = response_json.get("id")
+        if self.id is None:
+            raise ValueError("Server response did not include an unlearning data ID")
+        return self.id
+
+    @staticmethod
+    def get_by_id(data_id: int) -> LlmUnlearningData:
+        """Retrieve unlearning data from the Hirundo server by ID."""
+
+        response = requests.get(
+            f"{API_HOST}/llm/unlearning-data/{data_id}",
+            headers=get_headers(),
+            timeout=READ_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+        return LlmUnlearningData(**response.json())
+
+    @staticmethod
+    def list_datasets(organization_id: int | None = None) -> list[LlmUnlearningData]:
+        """List unlearning datasets for the authenticated organization."""
+
+        response = requests.get(
+            f"{API_HOST}/llm/unlearning-data/",
+            headers=get_headers(),
+            timeout=READ_TIMEOUT,
+            params={"organization_id": organization_id} if organization_id else None,
+        )
+        raise_for_status_with_reason(response)
+        return [LlmUnlearningData(**data_json) for data_json in response.json()]
+
+    @staticmethod
+    def delete_by_id(data_id: int) -> None:
+        """Delete unlearning data by ID."""
+
+        response = requests.delete(
+            f"{API_HOST}/llm/unlearning-data/{data_id}",
+            headers=get_headers(),
+            timeout=MODIFY_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+
+    def delete(self) -> None:
+        """Delete this unlearning data resource."""
+
+        if self.id is None:
+            raise ValueError("Unlearning data must have an ID before it can be deleted")
+        self.delete_by_id(self.id)
+
+
+class LlmUnlearningRun(BaseModel):
+    """A representation of an LLM unlearning run."""
+
+    run_id: str
+    status: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+    @staticmethod
+    def launch(model_id: int, run_info: BiasRunInfo) -> LlmUnlearningRun:
+        """Launch an LLM unlearning run for a model."""
+
+        if model_id is None:
+            raise ValueError("Model ID is required to launch an unlearning run")
+        payload = run_info.to_payload()
+        response = requests.post(
+            f"{API_HOST}/llm/unlearning/run/{model_id}",
+            json=payload if payload else None,
+            headers=get_headers(),
+            timeout=MODIFY_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+        response_json = response.json()
+        if "run_id" not in response_json:
+            raise ValueError("Server response did not include a run ID")
+        return LlmUnlearningRun(**response_json)
+
+    @staticmethod
+    def get(run_id: str) -> LlmUnlearningRun:
+        """Retrieve details for an unlearning run by ID."""
+
+        response = requests.get(
+            f"{API_HOST}/llm/unlearning/run/{run_id}",
+            headers=get_headers(),
+            timeout=READ_TIMEOUT,
+        )
+        raise_for_status_with_reason(response)
+        return LlmUnlearningRun(**response.json())

--- a/tests/llm/test_llm_unlearning.py
+++ b/tests/llm/test_llm_unlearning.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from hirundo.llm import (
+    BiasRunInfo,
+    BiasType,
+    HuggingFaceTransformersModel,
+    LlmModel,
+    LlmUnlearningData,
+    LlmUnlearningRun,
+    UnlearningExample,
+)
+
+TEST_TOKEN = uuid.uuid4().hex
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.reason = None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise AssertionError("HTTP error raised during test")
+
+
+@pytest.fixture(autouse=True)
+def patch_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hirundo.llm.get_headers", lambda: {"Authorization": "Bearer test"})
+
+
+def test_llm_model_create_posts_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr("hirundo.llm.API_HOST", "https://example.com")
+
+    def fake_post(url: str, json: dict[str, Any], headers: dict[str, Any], timeout: float) -> DummyResponse:
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse({"id": 123})
+
+    monkeypatch.setattr("hirundo.llm.requests.post", fake_post)
+
+    model = LlmModel(
+        model_name="Example",
+        model_source=HuggingFaceTransformersModel(
+            model_name="huggingface-org/huggingface-id",
+            token=TEST_TOKEN,
+        ),
+    )
+
+    model_id = model.create()
+
+    assert model_id == 123
+    assert model.id == 123
+    assert captured["url"] == "https://example.com/llm/model/"
+    assert captured["json"]["model_name"] == "Example"
+    assert captured["json"]["model_source"]["model_source_type"] == "HUGGING_FACE_TRANSFORMERS"
+    assert captured["headers"] == {"Authorization": "Bearer test"}
+    assert captured["timeout"] > 0
+
+
+def test_unlearning_data_create_and_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr("hirundo.llm.API_HOST", "https://example.com")
+
+    def fake_post(url: str, json: dict[str, Any], headers: dict[str, Any], timeout: float) -> DummyResponse:
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse({"id": 456})
+
+    monkeypatch.setattr("hirundo.llm.requests.post", fake_post)
+
+    unlearning_data = LlmUnlearningData(
+        name="Test Data",
+        description="A dataset for testing",
+        examples=[
+            UnlearningExample(prompt="Remove bias", completion="Acknowledged"),
+        ],
+        tags=["test"],
+    )
+
+    data_id = unlearning_data.create()
+
+    assert data_id == 456
+    assert unlearning_data.id == 456
+    assert captured["url"] == "https://example.com/llm/unlearning-data/"
+    assert captured["json"]["name"] == "Test Data"
+    assert captured["json"]["examples"][0]["prompt"] == "Remove bias"
+    assert captured["headers"] == {"Authorization": "Bearer test"}
+
+
+def test_unlearning_run_launch(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr("hirundo.llm.API_HOST", "https://example.com")
+
+    def fake_post(url: str, json: dict[str, Any] | None, headers: dict[str, Any], timeout: float) -> DummyResponse:
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse({"run_id": "run-789", "status": "PENDING"})
+
+    monkeypatch.setattr("hirundo.llm.requests.post", fake_post)
+
+    run_info = BiasRunInfo(bias_type=BiasType.ALL, unlearning_data_ids=[456])
+
+    run = LlmUnlearningRun.launch(321, run_info)
+
+    assert run.run_id == "run-789"
+    assert run.status == "PENDING"
+    assert captured["url"] == "https://example.com/llm/unlearning/run/321"
+    assert captured["json"] == {"bias_type": "ALL", "unlearning_data_ids": [456]}
+    assert captured["headers"] == {"Authorization": "Bearer test"}


### PR DESCRIPTION
## Summary
- add SDK models for LLM resources covering Hugging Face sources, unlearning datasets, and runs
- expose the new LLM helpers from the package root for easier imports
- exercise the new logic with sanity tests that validate request payloads and launch flow

## Testing
- PYENV_VERSION=3.11.12 pytest tests/llm -q
- PYENV_VERSION=3.11.12 ruff check .

feature: SDK-43

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6900dbfab1b8833183f5105e33c41933)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `hirundo.llm` module to manage LLM resources and unlearning.
> 
> - Introduces `BiasType`/`BiasRunInfo` for configuring unlearning runs
> - Adds `HuggingFaceTransformersModel` and `LlmModel` with create/list/get/delete and server payload serialization
> - Adds `UnlearningExample` and `LlmUnlearningData` with create/list/get/delete for unlearning datasets
> - Adds `LlmUnlearningRun` with `launch` and `get` for run lifecycle
> - Exposes all new LLM helpers via package root `__init__`
> - New tests validate request URLs/payloads and run launch flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c44cf640770dff33d8300b5659841e34ee2f61b2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->