### PR TITLE
SDK-82: Fix create-release workflow Python version quoting

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: 'pip'
       - name: Bump version with `bumpver` then push tag
         env:


### PR DESCRIPTION
### Motivation
- The GitHub Actions `create-release` workflow used an unquoted `3.10` value which can be parsed incorrectly by YAML parsers, so the Python version must be quoted to ensure the runner receives the intended string.

### Description
- Quote the Python version in ` .github/workflows/create-release.yaml` by changing `python-version: 3.10` to `python-version: "3.10"`, addressing YAML parsing issues and tracking the change with `feature: SDK-82`.

### Testing
- Ran `ruff check .` and `ruff format .`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a777350b483319eba4e1f165fd7d2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line CI workflow change that only affects how the runner interprets the Python version string.
> 
> **Overview**
> Ensures the `create-release` GitHub Actions workflow passes Python `3.10` as a quoted string (`python-version: "3.10"`) so YAML parsing can’t coerce it into an unintended value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c5eb412046e340018988ac9b134c676ea84056a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->