### PR TITLE
SDK-83: Upgrading to `actions/setup-python` version 6 to get improvements & dropping `python-version`

### DIFF
--- a/.github/workflows/cleanup-test-artifacts.yaml
+++ b/.github/workflows/cleanup-test-artifacts.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -28,9 +28,8 @@ jobs:
         with:
           ref: ${{ github.event.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
           cache: 'pip'
       - name: Bump version with `bumpver` then push tag
         env:

--- a/.github/workflows/deploy-to-pypi.yaml
+++ b/.github/workflows/deploy-to-pypi.yaml
@@ -23,9 +23,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.10
           cache: 'pip'
       - name: Push tag with release
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           cache: 'pip'
           python-version: ${{ matrix.python-version }}
@@ -42,7 +42,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           cache: 'pip'
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytest-full.yaml
+++ b/.github/workflows/pytest-full.yaml
@@ -29,9 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.10
           cache: 'pip'
       - name: Install dependencies on Linux and macOS
         run: |

--- a/.github/workflows/pytest-sanity.yaml
+++ b/.github/workflows/pytest-sanity.yaml
@@ -46,7 +46,7 @@ jobs:
           fi
       - name: Set up Python
         if: github.event_name != 'pull_request' && steps.changes.outputs.non_workflow == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          cache: 'pip'
       - name: Install dependencies
         timeout-minutes: 5
         env:


### PR DESCRIPTION
It defaults to `.python-version` which will correctly be read as a string unlike the mistakes in the YAML with no quote marks being read as `3.1` instead of `3.10` Also adding `cache: 'pip'` to `update-docs.yaml` to match the others

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/release workflows now rely more on `actions/setup-python@v6` defaults (and `.python-version`) instead of explicit `python-version`, which could change the runtime used for builds, tests, and publishing if the repo version file differs or is missing.
> 
> **Overview**
> Updates GitHub Actions workflows to use `actions/setup-python@v6` across cleanup, lint, test, release, publish, and docs pipelines.
> 
> Several jobs drop explicit `python-version: 3.10` and instead rely on the action’s default version resolution (e.g., `.python-version`), and `update-docs.yaml` also enables pip caching (`cache: 'pip'`) to match other workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41259eaee93e231ee54f31427604c309e6cc04f1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->