### PR TITLE
SDK-91: Refactor CLI into modular subcommands for eval, unlearning, and dataset-qa

### DIFF
--- a/docs/hirundo.cli_dataset_qa.rst
+++ b/docs/hirundo.cli_dataset_qa.rst
@@ -1,0 +1,10 @@
+.. meta::
+   :http-equiv=Content-Security-Policy: default-src 'self', frame-ancestors 'none'
+
+hirundo.cli_dataset_qa module
+=============================
+
+.. automodule:: hirundo.cli_dataset_qa
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/hirundo.cli_eval.rst
+++ b/docs/hirundo.cli_eval.rst
@@ -1,0 +1,10 @@
+.. meta::
+   :http-equiv=Content-Security-Policy: default-src 'self', frame-ancestors 'none'
+
+hirundo.cli_eval module
+=======================
+
+.. automodule:: hirundo.cli_eval
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/hirundo.cli_unlearning.rst
+++ b/docs/hirundo.cli_unlearning.rst
@@ -1,0 +1,10 @@
+.. meta::
+   :http-equiv=Content-Security-Policy: default-src 'self', frame-ancestors 'none'
+
+hirundo.cli_unlearning module
+=============================
+
+.. automodule:: hirundo.cli_unlearning
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -60,6 +60,12 @@ def wait_or_notify(
     return None
 
 
+def check_run_and_print(run_id: str, check_fn: Callable[[str], Any]) -> None:
+    results = check_fn(validate_run_id(run_id))
+    if results is not None:
+        console.print(f"Run results saved to {results.cached_zip_path}")
+
+
 def print_runs_table(
     title: str,
     columns: tuple[str, ...],

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -49,24 +49,34 @@ def validate_enum(value: str, enum_cls: type[Enum], label: str) -> Any:
         raise typer.Exit(code=1) from None
 
 
+def require_exactly_one(*options: tuple[str, Any]) -> None:
+    """Exit with an error unless exactly one of the named options is set."""
+    provided = [name for name, value in options if value is not None]
+    if len(provided) != 1:
+        names = " or ".join(name for name, _ in options)
+        console.print(f"[red]Error: exactly one of {names} must be provided.[/red]")
+        raise typer.Exit(code=1) from None
+
+
+def _report_results(results: Any) -> Any:
+    if results is not None:
+        console.print(f"Run results saved to {results.cached_zip_path}")
+    return results
+
+
 def wait_or_notify(
     run_id: str, check_fn: Callable[[str], Any], cmd_name: str, wait: bool
 ) -> Any:
-    if wait:
-        results = check_fn(run_id)
-        if results is not None:
-            console.print(f"Run results saved to {results.cached_zip_path}")
-        return results
-    console.print(
-        f"Use [bold]hirundo {cmd_name} check[/bold] [italic]<run_id>[/italic] to monitor progress."
-    )
-    return None
+    if not wait:
+        console.print(
+            f"Use [bold]hirundo {cmd_name} check[/bold] [italic]<run_id>[/italic] to monitor progress."
+        )
+        return None
+    return _report_results(check_fn(run_id))
 
 
 def check_run_and_print(run_id: str, check_fn: Callable[[str], Any]) -> None:
-    results = check_fn(validate_run_id(run_id))
-    if results is not None:
-        console.print(f"Run results saved to {results.cached_zip_path}")
+    _report_results(check_fn(validate_run_id(run_id)))
 
 
 def print_runs_table(

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -2,7 +2,7 @@ import re
 import sys
 from collections.abc import Callable
 from enum import Enum
-from typing import Any
+from typing import Annotated, Any, TypeAlias
 
 import typer
 from rich import box
@@ -39,6 +39,12 @@ def warn(message: str) -> None:
 def error(message: str) -> None:
     """Print an error message in red."""
     console.print(f"[red]{message}[/red]")
+
+
+ArchivedOption: TypeAlias = Annotated[
+    bool,
+    typer.Option("--archived/--no-archived", help="Include archived runs."),
+]
 
 
 def make_app(name: str, help_text: str) -> typer.Typer:

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -30,7 +30,7 @@ def make_app(name: str, help_text: str) -> typer.Typer:
 
 
 def validate_run_id(run_id: str) -> str:
-    if not _RUN_ID_RE.match(run_id):
+    if not _RUN_ID_RE.fullmatch(run_id):
         console.print(
             f"[red]Invalid run ID '{run_id}'. "
             "Run IDs may only contain alphanumeric characters, hyphens, and underscores.[/red]"

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Any
 
 import typer
+from rich import box
 from rich.console import Console
 from rich.table import Table
 
@@ -21,23 +22,23 @@ console = Console()
 
 
 def success(message: str) -> None:
-    """Print a success message with a green check icon."""
-    console.print(f"[bold green]✓[/bold green] {message}")
+    """Print a success message in green."""
+    console.print(f"[green]{message}[/green]")
 
 
 def info(message: str) -> None:
-    """Print an informational message with a cyan info icon."""
-    console.print(f"[bold cyan]ℹ[/bold cyan] {message}")
+    """Print a plain informational message."""
+    console.print(message)
 
 
 def warn(message: str) -> None:
-    """Print a warning message with a yellow icon."""
-    console.print(f"[bold yellow]![/bold yellow] {message}")
+    """Print a warning message in yellow."""
+    console.print(f"[yellow]{message}[/yellow]")
 
 
 def error(message: str) -> None:
-    """Print an error message with a red cross icon."""
-    console.print(f"[bold red]✗[/bold red] {message}")
+    """Print an error message in red."""
+    console.print(f"[red]{message}[/red]")
 
 
 def make_app(name: str, help_text: str) -> typer.Typer:
@@ -110,7 +111,13 @@ def print_runs_table(
     columns: tuple[str, ...],
     rows: list[tuple[str | None, ...]],
 ) -> None:
-    table = Table(title=title, expand=True)
+    table = Table(
+        title=title,
+        box=box.SIMPLE,
+        show_lines=False,
+        show_edge=True,
+        header_style="bold",
+    )
     for col in columns:
         table.add_column(col, overflow="fold")
     for row in rows:

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -44,7 +44,7 @@ def validate_enum(value: str, enum_cls: type[Enum], label: str) -> Any:
     try:
         return enum_cls(value.upper())
     except ValueError:
-        valid = ", ".join(e.value for e in enum_cls)
+        valid = ", ".join(member.value for member in enum_cls)
         console.print(f"[red]Invalid {label} '{value}'. Valid options: {valid}[/red]")
         raise typer.Exit(code=1) from None
 

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -1,8 +1,11 @@
 import re
 import sys
+from collections.abc import Callable
+from typing import Any
 
 import typer
 from rich.console import Console
+from rich.table import Table
 
 _RUN_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -36,10 +39,34 @@ def validate_run_id(run_id: str) -> str:
     return run_id
 
 
-def validate_enum(value: str, enum_cls, label: str):
+def validate_enum(value: str, enum_cls: type, label: str) -> Any:
     try:
         return enum_cls(value.upper())
     except ValueError:
         valid = ", ".join(e.value for e in enum_cls)
         console.print(f"[red]Invalid {label} '{value}'. Valid options: {valid}[/red]")
         raise typer.Exit(code=1) from None
+
+
+def wait_or_notify(
+    run_id: str, check_fn: Callable[[str], Any], cmd_name: str, wait: bool
+) -> Any:
+    if wait:
+        return check_fn(run_id)
+    console.print(
+        f"Use [bold]hirundo {cmd_name} check[/bold] [italic]<run_id>[/italic] to monitor progress."
+    )
+    return None
+
+
+def print_runs_table(
+    title: str,
+    columns: tuple[str, ...],
+    rows: list[tuple[str | None, ...]],
+) -> None:
+    table = Table(title=title, expand=True)
+    for col in columns:
+        table.add_column(col, overflow="fold")
+    for row in rows:
+        table.add_row(*row)
+    console.print(table)

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -53,7 +53,10 @@ def wait_or_notify(
     run_id: str, check_fn: Callable[[str], Any], cmd_name: str, wait: bool
 ) -> Any:
     if wait:
-        return check_fn(run_id)
+        results = check_fn(run_id)
+        if results is not None:
+            console.print(f"Run results saved to {results.cached_zip_path}")
+        return results
     console.print(
         f"Use [bold]hirundo {cmd_name} check[/bold] [italic]<run_id>[/italic] to monitor progress."
     )

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -1,7 +1,10 @@
+import re
 import sys
 
 import typer
 from rich.console import Console
+
+_RUN_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 docs = "sphinx" in sys.modules
 hirundo_epilog = (
@@ -21,6 +24,16 @@ def make_app(name: str, help_text: str) -> typer.Typer:
         epilog=hirundo_epilog,
         help=help_text,
     )
+
+
+def validate_run_id(run_id: str) -> str:
+    if not _RUN_ID_RE.match(run_id):
+        console.print(
+            f"[red]Invalid run ID '{run_id}'. "
+            "Run IDs may only contain alphanumeric characters, hyphens, and underscores.[/red]"
+        )
+        raise typer.Exit(code=1) from None
+    return run_id
 
 
 def validate_enum(value: str, enum_cls, label: str):

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -1,6 +1,7 @@
 import re
 import sys
 from collections.abc import Callable
+from enum import Enum
 from typing import Any
 
 import typer
@@ -39,7 +40,7 @@ def validate_run_id(run_id: str) -> str:
     return run_id
 
 
-def validate_enum(value: str, enum_cls: type, label: str) -> Any:
+def validate_enum(value: str, enum_cls: type[Enum], label: str) -> Any:
     try:
         return enum_cls(value.upper())
     except ValueError:

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -1,0 +1,32 @@
+import sys
+
+import typer
+from rich.console import Console
+
+docs = "sphinx" in sys.modules
+hirundo_epilog = (
+    None
+    if docs
+    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
+)
+
+console = Console()
+
+
+def make_app(name: str, help: str) -> typer.Typer:
+    return typer.Typer(
+        name=name,
+        no_args_is_help=True,
+        rich_markup_mode="rich",
+        epilog=hirundo_epilog,
+        help=help,
+    )
+
+
+def validate_enum(value: str, enum_cls, label: str):
+    try:
+        return enum_cls(value.upper())
+    except ValueError:
+        valid = ", ".join(e.value for e in enum_cls)
+        console.print(f"[red]Invalid {label} '{value}'. Valid options: {valid}[/red]")
+        raise typer.Exit(code=1)

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -46,6 +46,13 @@ ArchivedOption: TypeAlias = Annotated[
     typer.Option("--archived/--no-archived", help="Include archived runs."),
 ]
 
+WaitOption: TypeAlias = Annotated[
+    bool,
+    typer.Option(
+        "--wait/--no-wait", help="Wait for the run to complete and stream progress."
+    ),
+]
+
 
 def make_app(name: str, help_text: str) -> typer.Typer:
     return typer.Typer(

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -85,7 +85,7 @@ def report_run_started(label: str, run_id: str) -> None:
 
 
 def _report_results(results: Any) -> Any:
-    if results is not None:
+    if results is not None and hasattr(results, "cached_zip_path"):
         success(f"Run results saved to [bold]{results.cached_zip_path}[/bold]")
     return results
 

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -20,6 +20,26 @@ hirundo_epilog = (
 console = Console()
 
 
+def success(message: str) -> None:
+    """Print a success message with a green check icon."""
+    console.print(f"[bold green]✓[/bold green] {message}")
+
+
+def info(message: str) -> None:
+    """Print an informational message with a cyan info icon."""
+    console.print(f"[bold cyan]ℹ[/bold cyan] {message}")
+
+
+def warn(message: str) -> None:
+    """Print a warning message with a yellow icon."""
+    console.print(f"[bold yellow]![/bold yellow] {message}")
+
+
+def error(message: str) -> None:
+    """Print an error message with a red cross icon."""
+    console.print(f"[bold red]✗[/bold red] {message}")
+
+
 def make_app(name: str, help_text: str) -> typer.Typer:
     return typer.Typer(
         name=name,
@@ -32,9 +52,9 @@ def make_app(name: str, help_text: str) -> typer.Typer:
 
 def validate_run_id(run_id: str) -> str:
     if not _RUN_ID_RE.fullmatch(run_id):
-        console.print(
-            f"[red]Invalid run ID '{run_id}'. "
-            "Run IDs may only contain alphanumeric characters, hyphens, and underscores.[/red]"
+        error(
+            f"Invalid run ID '{run_id}'. Run IDs may only contain "
+            "alphanumeric characters, hyphens, and underscores."
         )
         raise typer.Exit(code=1) from None
     return run_id
@@ -45,7 +65,7 @@ def validate_enum(value: str, enum_cls: type[Enum], label: str) -> Any:
         return enum_cls(value.upper())
     except ValueError:
         valid = ", ".join(member.value for member in enum_cls)
-        console.print(f"[red]Invalid {label} '{value}'. Valid options: {valid}[/red]")
+        error(f"Invalid {label} '{value}'. Valid options: {valid}.")
         raise typer.Exit(code=1) from None
 
 
@@ -54,13 +74,18 @@ def require_exactly_one(*options: tuple[str, Any]) -> None:
     provided = [name for name, value in options if value is not None]
     if len(provided) != 1:
         names = " or ".join(name for name, _ in options)
-        console.print(f"[red]Error: exactly one of {names} must be provided.[/red]")
+        error(f"Exactly one of {names} must be provided.")
         raise typer.Exit(code=1) from None
+
+
+def report_run_started(label: str, run_id: str) -> None:
+    """Announce a freshly launched run in a consistent style."""
+    success(f"{label} run started — Run ID: [bold]{run_id}[/bold]")
 
 
 def _report_results(results: Any) -> Any:
     if results is not None:
-        console.print(f"Run results saved to {results.cached_zip_path}")
+        success(f"Run results saved to [bold]{results.cached_zip_path}[/bold]")
     return results
 
 
@@ -68,8 +93,9 @@ def wait_or_notify(
     run_id: str, check_fn: Callable[[str], Any], cmd_name: str, wait: bool
 ) -> Any:
     if not wait:
-        console.print(
-            f"Use [bold]hirundo {cmd_name} check[/bold] [italic]<run_id>[/italic] to monitor progress."
+        info(
+            f"Use [bold]hirundo {cmd_name} check[/bold] [italic]<run_id>[/italic] "
+            "to monitor progress."
         )
         return None
     return _report_results(check_fn(run_id))

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -13,13 +13,13 @@ hirundo_epilog = (
 console = Console()
 
 
-def make_app(name: str, help: str) -> typer.Typer:
+def make_app(name: str, help_text: str) -> typer.Typer:
     return typer.Typer(
         name=name,
         no_args_is_help=True,
         rich_markup_mode="rich",
         epilog=hirundo_epilog,
-        help=help,
+        help=help_text,
     )
 
 
@@ -29,4 +29,4 @@ def validate_enum(value: str, enum_cls, label: str):
     except ValueError:
         valid = ", ".join(e.value for e in enum_cls)
         console.print(f"[red]Invalid {label} '{value}'. Valid options: {valid}[/red]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -61,14 +61,14 @@ def _upsert_env(dotenv_filepath: str | Path, var_name: str, var_value: str):
 
 
 def upsert_env(var_name: str, var_value: str):
-    if os.path.exists(EnvLocation.DOTENV.value):
-        # If a `.env` file exists, re-use it
-        _upsert_env(EnvLocation.DOTENV.value, var_name, var_value)
-        return EnvLocation.DOTENV.name
-    else:
-        # Create a `.hirundo.conf` file with environment variables in the home directory
-        _upsert_env(EnvLocation.HOME.value, var_name, var_value)
-        return EnvLocation.HOME.name
+    # Re-use a local `.env` if present, otherwise fall back to `~/.hirundo.conf`.
+    location = (
+        EnvLocation.DOTENV
+        if os.path.exists(EnvLocation.DOTENV.value)
+        else EnvLocation.HOME
+    )
+    _upsert_env(location.value, var_name, var_value)
+    return location.name
 
 
 # Shared option definitions reused across set-api-key, change-remote, and setup.
@@ -96,7 +96,7 @@ _API_HOST_OPTION: TypeAlias = Annotated[
 
 
 def fix_api_host(api_host: str):
-    if not api_host.startswith("http") and not api_host.startswith("https"):
+    if not api_host.startswith(("http://", "https://")):
         api_host = f"https://{api_host}"
         warn("API host must start with 'http://' or 'https://'. Added 'https://'.")
     if (url := urlparse(api_host)) and url.path != "":

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -1,25 +1,17 @@
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Annotated
 from urllib.parse import urlparse
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from hirundo._cli_common import console, docs, hirundo_epilog
 from hirundo._env import API_HOST, EnvLocation
 from hirundo.cli_dataset_qa import dataset_qa_app
 from hirundo.cli_eval import eval_app
 from hirundo.cli_unlearning import unlearning_app
-
-docs = "sphinx" in sys.modules
-hirundo_epilog = (
-    None
-    if docs
-    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
-)
 
 
 app = typer.Typer(
@@ -217,7 +209,6 @@ def list_runs():
 
     runs = QADataset.list_runs()
 
-    console = Console()
     table = Table(
         title="Runs:",
         expand=True,

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, TypeAlias
 from urllib.parse import urlparse
 
 import typer
@@ -71,6 +71,30 @@ def upsert_env(var_name: str, var_value: str):
         return EnvLocation.HOME.name
 
 
+# Shared option definitions reused across set-api-key, change-remote, and setup.
+_API_KEY_OPTION: TypeAlias = Annotated[
+    str,
+    typer.Option(
+        prompt="Please enter the API key value",
+        help="" if docs else f"Visit '{API_HOST}/api-key' to generate your API key.",
+    ),
+]
+
+# TODO: Change to HttpUrl when https://github.com/tiangolo/typer/pull/723 is merged
+_API_HOST_OPTION: TypeAlias = Annotated[
+    str,
+    typer.Option(
+        prompt="Please enter the API server address",
+        help=""
+        if docs
+        else (
+            f"Current API server address: '{API_HOST}'. "
+            "This is the same address where you access the Hirundo web interface."
+        ),
+    ),
+]
+
+
 def fix_api_host(api_host: str):
     if not api_host.startswith("http") and not api_host.startswith("https"):
         api_host = f"https://{api_host}"
@@ -82,17 +106,7 @@ def fix_api_host(api_host: str):
 
 
 @app.command("set-api-key", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
-def setup_api_key(
-    api_key: Annotated[
-        str,
-        typer.Option(
-            prompt="Please enter the API key value",
-            help=""
-            if docs
-            else f"Visit '{API_HOST}/api-key' to generate your API key.",
-        ),
-    ],
-):
+def setup_api_key(api_key: _API_KEY_OPTION):
     """
     Save the API key for the Hirundo SDK.
 
@@ -105,17 +119,7 @@ def setup_api_key(
 
 
 @app.command("change-remote", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
-def change_api_remote(
-    api_host: Annotated[
-        str,  # TODO: Change to HttpUrl when https://github.com/tiangolo/typer/pull/723 is merged
-        typer.Option(
-            prompt="Please enter the API server address",
-            help=""
-            if docs
-            else f"Current API server address: '{API_HOST}'. This is the same address where you access the Hirundo web interface.",
-        ),
-    ],
-):
+def change_api_remote(api_host: _API_HOST_OPTION):
     """
     Change the API server address (same URL as the Hirundo web interface).
     """
@@ -126,26 +130,7 @@ def change_api_remote(
 
 
 @app.command("setup", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
-def setup(
-    api_key: Annotated[
-        str,
-        typer.Option(
-            prompt="Please enter the API key value",
-            help=""
-            if docs
-            else f"Visit '{API_HOST}/api-key' to generate your API key.",
-        ),
-    ],
-    api_host: Annotated[
-        str,  # TODO: Change to HttpUrl as above
-        typer.Option(
-            prompt="Please enter the API server address",
-            help=""
-            if docs
-            else f"Current API server address: '{API_HOST}'. This is the same address where you access the Hirundo web interface.",
-        ),
-    ],
-):
+def setup(api_key: _API_KEY_OPTION, api_host: _API_HOST_OPTION):
     """
     Setup the Hirundo Python SDK.
     """

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -10,6 +10,9 @@ from rich.console import Console
 from rich.table import Table
 
 from hirundo._env import API_HOST, EnvLocation
+from hirundo.cli_dataset_qa import dataset_qa_app
+from hirundo.cli_eval import eval_app
+from hirundo.cli_unlearning import unlearning_app
 
 docs = "sphinx" in sys.modules
 hirundo_epilog = (
@@ -25,6 +28,10 @@ app = typer.Typer(
     rich_markup_mode="rich",
     epilog=hirundo_epilog,
 )
+
+app.add_typer(eval_app, name="eval")
+app.add_typer(dataset_qa_app, name="dataset-qa")
+app.add_typer(unlearning_app, name="unlearning")
 
 
 def _upsert_env(dotenv_filepath: str | Path, var_name: str, var_value: str):

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -6,22 +6,38 @@ from urllib.parse import urlparse
 
 import typer
 
-from hirundo._cli_common import docs, hirundo_epilog
+from hirundo._cli_common import docs, hirundo_epilog, success, warn
 from hirundo._env import API_HOST, EnvLocation
 from hirundo.cli_dataset_qa import dataset_qa_app, dataset_qa_check, dataset_qa_list
 from hirundo.cli_eval import eval_app
 from hirundo.cli_unlearning import unlearning_app
+
+_CONFIG_PANEL = "Configuration"
+_RUNS_PANEL = "Runs"
+_PIPELINES_PANEL = "Pipelines"
 
 app = typer.Typer(
     name="hirundo",
     no_args_is_help=True,
     rich_markup_mode="rich",
     epilog=hirundo_epilog,
+    help=(
+        "[bold]Hirundo[/bold] — launch and monitor data-quality, "
+        "unlearning, and evaluation runs from your terminal.\n\n"
+        "Run [bold]hirundo setup[/bold] once to store your API key, then use the "
+        "[bold]eval[/bold], [bold]dataset-qa[/bold], and [bold]unlearning[/bold] "
+        "command groups to launch work."
+    ),
 )
 
-app.add_typer(eval_app, name="eval")
-app.add_typer(dataset_qa_app, name="dataset-qa")
-app.add_typer(unlearning_app, name="unlearning")
+app.add_typer(eval_app, name="eval", rich_help_panel=_PIPELINES_PANEL)
+app.add_typer(dataset_qa_app, name="dataset-qa", rich_help_panel=_PIPELINES_PANEL)
+app.add_typer(unlearning_app, name="unlearning", rich_help_panel=_PIPELINES_PANEL)
+
+
+def _location_label(saved_to: str) -> str:
+    """Human-friendly name of the file an env var was written to."""
+    return "~/.hirundo.conf" if saved_to == EnvLocation.HOME.name else ".env"
 
 
 def _upsert_env(dotenv_filepath: str | Path, var_name: str, var_value: str):
@@ -60,16 +76,14 @@ def upsert_env(var_name: str, var_value: str):
 def fix_api_host(api_host: str):
     if not api_host.startswith("http") and not api_host.startswith("https"):
         api_host = f"https://{api_host}"
-        print(
-            "API host must start with 'http://' or 'https://'. Automatically added 'https://'."
-        )
+        warn("API host must start with 'http://' or 'https://'. Added 'https://'.")
     if (url := urlparse(api_host)) and url.path != "":
-        print("API host should not contain a path. Removing path.")
+        warn("API host should not contain a path. Removing it.")
         api_host = f"{url.scheme}://{url.hostname}"
     return api_host
 
 
-@app.command("set-api-key", epilog=hirundo_epilog)
+@app.command("set-api-key", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
 def setup_api_key(
     api_key: Annotated[
         str,
@@ -85,18 +99,12 @@ def setup_api_key(
     Setup the API key for the Hirundo Python SDK.
     Values are saved to a .env file in the current directory for use by the library in requests.
     """
-    saved_to = upsert_env("API_KEY", api_key)
-    if saved_to == EnvLocation.HOME.name:
-        print(
-            "API key saved to ~/.hirundo.conf for future use. Please do not share the ~/.hirundo.conf file since it contains your secret API key."
-        )
-    elif saved_to == EnvLocation.DOTENV.name:
-        print(
-            "API key saved to local .env file for future use. Please do not share the .env file since it contains your secret API key."
-        )
+    location = _location_label(upsert_env("API_KEY", api_key))
+    success(f"API key saved to [bold]{location}[/bold].")
+    warn(f"Keep [bold]{location}[/bold] private — it contains your secret API key.")
 
 
-@app.command("change-remote", epilog=hirundo_epilog)
+@app.command("change-remote", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
 def change_api_remote(
     api_host: Annotated[
         str,  # TODO: Change to HttpUrl when https://github.com/tiangolo/typer/pull/723 is merged
@@ -114,16 +122,11 @@ def change_api_remote(
     """
     api_host = fix_api_host(api_host)
 
-    saved_to = upsert_env("API_HOST", api_host)
-    if saved_to == EnvLocation.HOME.name:
-        print(
-            "API host saved to ~/.hirundo.conf for future use. Please do not share the ~/.hirundo.conf file"
-        )
-    elif saved_to == EnvLocation.DOTENV.name:
-        print("API host saved to .env for future use. Please do not share this file")
+    location = _location_label(upsert_env("API_HOST", api_host))
+    success(f"API host saved to [bold]{location}[/bold].")
 
 
-@app.command("setup", epilog=hirundo_epilog)
+@app.command("setup", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
 def setup(
     api_key: Annotated[
         str,
@@ -148,44 +151,15 @@ def setup(
     Setup the Hirundo Python SDK.
     """
     api_host = fix_api_host(api_host)
-    api_host_saved_to = upsert_env("API_HOST", api_host)
-    api_key_saved_to = upsert_env("API_KEY", api_key)
-    if api_host_saved_to != api_key_saved_to:
-        print(
-            "API host and API key saved to different locations. This should not happen. Please report this issue."
-        )
-        if (
-            api_host_saved_to == EnvLocation.HOME.name
-            and api_key_saved_to == EnvLocation.DOTENV.name
-        ):
-            print(
-                "API host saved to ~/.hirundo.conf for future use. Please do not share the ~/.hirundo.conf file"
-            )
-            print(
-                "API key saved to local .env file for future use. Please do not share the .env file since it contains your secret API key."
-            )
-        elif (
-            api_host_saved_to == EnvLocation.DOTENV.name
-            and api_key_saved_to == EnvLocation.HOME.name
-        ):
-            print(
-                "API host saved to .env for future use. Please do not share this file"
-            )
-            print(
-                "API key saved to ~/.hirundo.conf for future use. Please do not share the ~/.hirundo.conf file since it contains your secret API key."
-            )
-        return
-    if api_host_saved_to == EnvLocation.HOME.name:
-        print(
-            "API host and API key saved to ~/.hirundo.conf for future use. Please do not share the ~/.hirundo.conf file since it contains your secret API key."
-        )
-    elif api_host_saved_to == EnvLocation.DOTENV.name:
-        print(
-            "API host and API key saved to .env for future use. Please do not share this file since it contains your secret API key."
-        )
+    host_location = _location_label(upsert_env("API_HOST", api_host))
+    key_location = _location_label(upsert_env("API_KEY", api_key))
+
+    success(f"API host saved to [bold]{host_location}[/bold].")
+    success(f"API key saved to [bold]{key_location}[/bold].")
+    warn(f"Keep [bold]{key_location}[/bold] private — it contains your secret API key.")
 
 
-@app.command("check-run", epilog=hirundo_epilog)
+@app.command("check-run", epilog=hirundo_epilog, rich_help_panel=_RUNS_PANEL)
 def check_run(
     run_id: str,
 ):
@@ -195,7 +169,7 @@ def check_run(
     dataset_qa_check(run_id)
 
 
-@app.command("list-runs", epilog=hirundo_epilog)
+@app.command("list-runs", epilog=hirundo_epilog, rich_help_panel=_RUNS_PANEL)
 def list_runs():
     """
     List all runs available.

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -6,9 +6,9 @@ from urllib.parse import urlparse
 
 import typer
 
-from hirundo._cli_common import check_run_and_print, docs, hirundo_epilog
+from hirundo._cli_common import docs, hirundo_epilog
 from hirundo._env import API_HOST, EnvLocation
-from hirundo.cli_dataset_qa import dataset_qa_app, dataset_qa_list
+from hirundo.cli_dataset_qa import dataset_qa_app, dataset_qa_check, dataset_qa_list
 from hirundo.cli_eval import eval_app
 from hirundo.cli_unlearning import unlearning_app
 
@@ -192,9 +192,7 @@ def check_run(
     """
     Check the status of a run.
     """
-    from hirundo.dataset_qa import QADataset
-
-    check_run_and_print(run_id, QADataset.check_run_by_id)
+    dataset_qa_check(run_id)
 
 
 @app.command("list-runs", epilog=hirundo_epilog)

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 import typer
 
-from hirundo._cli_common import docs, hirundo_epilog, validate_run_id
+from hirundo._cli_common import check_run_and_print, docs, hirundo_epilog
 from hirundo._env import API_HOST, EnvLocation
 from hirundo.cli_dataset_qa import dataset_qa_app, dataset_qa_list
 from hirundo.cli_eval import eval_app
@@ -194,9 +194,7 @@ def check_run(
     """
     from hirundo.dataset_qa import QADataset
 
-    results = QADataset.check_run_by_id(validate_run_id(run_id))
-    if results is not None:
-        print(f"Run results saved to {results.cached_zip_path}")
+    check_run_and_print(run_id, QADataset.check_run_by_id)
 
 
 @app.command("list-runs", epilog=hirundo_epilog)

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -5,9 +5,8 @@ from typing import Annotated
 from urllib.parse import urlparse
 
 import typer
-from rich.table import Table
 
-from hirundo._cli_common import console, docs, hirundo_epilog
+from hirundo._cli_common import docs, hirundo_epilog, print_runs_table
 from hirundo._env import API_HOST, EnvLocation
 from hirundo.cli_dataset_qa import dataset_qa_app
 from hirundo.cli_eval import eval_app
@@ -207,32 +206,20 @@ def list_runs():
     from hirundo.dataset_qa import QADataset
 
     runs = QADataset.list_runs()
-
-    table = Table(
-        title="Runs:",
-        expand=True,
+    print_runs_table(
+        "Runs:",
+        ("Dataset name", "Run ID", "Status", "Created At", "Run Args"),
+        [
+            (
+                str(run.name),
+                str(run.run_id),
+                str(run.status),
+                run.created_at.isoformat(),
+                run.run_args.model_dump_json() if run.run_args else None,
+            )
+            for run in runs
+        ],
     )
-    cols = (
-        "Dataset name",
-        "Run ID",
-        "Status",
-        "Created At",
-        "Run Args",
-    )
-    for col in cols:
-        table.add_column(
-            col,
-            overflow="fold",
-        )
-    for run in runs:
-        table.add_row(
-            str(run.name),
-            str(run.run_id),
-            str(run.status),
-            run.created_at.isoformat(),
-            run.run_args.model_dump_json() if run.run_args else None,
-        )
-    console.print(table)
 
 
 typer_click_object = typer.main.get_command(app)

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -22,11 +22,9 @@ app = typer.Typer(
     rich_markup_mode="rich",
     epilog=hirundo_epilog,
     help=(
-        "[bold]Hirundo[/bold] — launch and monitor data-quality, "
-        "unlearning, and evaluation runs from your terminal.\n\n"
-        "Run [bold]hirundo setup[/bold] once to store your API key, then use the "
-        "[bold]eval[/bold], [bold]dataset-qa[/bold], and [bold]unlearning[/bold] "
-        "command groups to launch work."
+        "Launch and monitor Hirundo data-quality, unlearning, and evaluation "
+        "runs. Run `hirundo setup` once to store your API key, then use the "
+        "eval, dataset-qa, and unlearning command groups."
     ),
 )
 

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -57,9 +57,7 @@ def _upsert_env(dotenv_filepath: str | Path, var_name: str, var_value: str):
         f.writelines(line for line in lines if not regex.search(line) and line != "\n")
 
     with open(dotenv_filepath, "a") as f:
-        f.writelines(
-            f"\n{var_name}={var_value}"
-        )  # lgtm[py/clear-text-storage-sensitive-data]
+        f.writelines(f"\n{var_name}={var_value}")
 
 
 def upsert_env(var_name: str, var_value: str):

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -94,8 +94,10 @@ def setup_api_key(
     ],
 ):
     """
-    Setup the API key for the Hirundo Python SDK.
-    Values are saved to a .env file in the current directory for use by the library in requests.
+    Save the API key for the Hirundo SDK.
+
+    The key is written to a local .env file (or ~/.hirundo.conf if no .env
+    exists) and picked up automatically on subsequent commands.
     """
     location = _location_label(upsert_env("API_KEY", api_key))
     success(f"API key saved to [bold]{location}[/bold].")
@@ -115,8 +117,7 @@ def change_api_remote(
     ],
 ):
     """
-    Change the API server address for the Hirundo Python SDK.
-    This is the same address where you access the Hirundo web interface.
+    Change the API server address (same URL as the Hirundo web interface).
     """
     api_host = fix_api_host(api_host)
 

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -13,7 +13,6 @@ from hirundo.cli_dataset_qa import dataset_qa_app
 from hirundo.cli_eval import eval_app
 from hirundo.cli_unlearning import unlearning_app
 
-
 app = typer.Typer(
     name="hirundo",
     no_args_is_help=True,

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -57,7 +57,7 @@ def _upsert_env(dotenv_filepath: str | Path, var_name: str, var_value: str):
         f.writelines(line for line in lines if not regex.search(line) and line != "\n")
 
     with open(dotenv_filepath, "a") as f:
-        f.writelines(f"\n{var_name}={var_value}")
+        f.writelines(f"\n{var_name}={var_value}")  # lgtm[py/clear-text-storage-sensitive-data]
 
 
 def upsert_env(var_name: str, var_value: str):

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -6,9 +6,9 @@ from urllib.parse import urlparse
 
 import typer
 
-from hirundo._cli_common import docs, hirundo_epilog, print_runs_table
+from hirundo._cli_common import docs, hirundo_epilog, validate_run_id
 from hirundo._env import API_HOST, EnvLocation
-from hirundo.cli_dataset_qa import dataset_qa_app
+from hirundo.cli_dataset_qa import dataset_qa_app, dataset_qa_list
 from hirundo.cli_eval import eval_app
 from hirundo.cli_unlearning import unlearning_app
 
@@ -194,8 +194,9 @@ def check_run(
     """
     from hirundo.dataset_qa import QADataset
 
-    results = QADataset.check_run_by_id(run_id)
-    print(f"Run results saved to {results.cached_zip_path}")
+    results = QADataset.check_run_by_id(validate_run_id(run_id))
+    if results is not None:
+        print(f"Run results saved to {results.cached_zip_path}")
 
 
 @app.command("list-runs", epilog=hirundo_epilog)
@@ -203,23 +204,7 @@ def list_runs():
     """
     List all runs available.
     """
-    from hirundo.dataset_qa import QADataset
-
-    runs = QADataset.list_runs()
-    print_runs_table(
-        "Runs:",
-        ("Dataset name", "Run ID", "Status", "Created At", "Run Args"),
-        [
-            (
-                str(run.name),
-                str(run.run_id),
-                str(run.status),
-                run.created_at.isoformat(),
-                run.run_args.model_dump_json() if run.run_args else None,
-            )
-            for run in runs
-        ],
-    )
+    dataset_qa_list(archived=False)
 
 
 typer_click_object = typer.main.get_command(app)

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -227,7 +227,7 @@ def list_runs():
     for run in runs:
         table.add_row(
             str(run.name),
-            str(run.id),
+            str(run.run_id),
             str(run.status),
             run.created_at.isoformat(),
             run.run_args.model_dump_json() if run.run_args else None,

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -57,7 +57,9 @@ def _upsert_env(dotenv_filepath: str | Path, var_name: str, var_value: str):
         f.writelines(line for line in lines if not regex.search(line) and line != "\n")
 
     with open(dotenv_filepath, "a") as f:
-        f.writelines(f"\n{var_name}={var_value}")  # lgtm[py/clear-text-storage-sensitive-data]
+        f.writelines(
+            f"\n{var_name}={var_value}"
+        )  # lgtm[py/clear-text-storage-sensitive-data]
 
 
 def upsert_env(var_name: str, var_value: str):
@@ -105,6 +107,17 @@ def fix_api_host(api_host: str):
     return api_host
 
 
+def _save_api_key(api_key: str) -> None:
+    location = _location_label(upsert_env("API_KEY", api_key))
+    success(f"API key saved to [bold]{location}[/bold].")
+    warn(f"Keep [bold]{location}[/bold] private — it contains your secret API key.")
+
+
+def _save_api_host(api_host: str) -> None:
+    location = _location_label(upsert_env("API_HOST", fix_api_host(api_host)))
+    success(f"API host saved to [bold]{location}[/bold].")
+
+
 @app.command("set-api-key", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
 def setup_api_key(api_key: _API_KEY_OPTION):
     """
@@ -113,9 +126,7 @@ def setup_api_key(api_key: _API_KEY_OPTION):
     The key is written to a local .env file (or ~/.hirundo.conf if no .env
     exists) and picked up automatically on subsequent commands.
     """
-    location = _location_label(upsert_env("API_KEY", api_key))
-    success(f"API key saved to [bold]{location}[/bold].")
-    warn(f"Keep [bold]{location}[/bold] private — it contains your secret API key.")
+    _save_api_key(api_key)
 
 
 @app.command("change-remote", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
@@ -123,10 +134,7 @@ def change_api_remote(api_host: _API_HOST_OPTION):
     """
     Change the API server address (same URL as the Hirundo web interface).
     """
-    api_host = fix_api_host(api_host)
-
-    location = _location_label(upsert_env("API_HOST", api_host))
-    success(f"API host saved to [bold]{location}[/bold].")
+    _save_api_host(api_host)
 
 
 @app.command("setup", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
@@ -134,13 +142,8 @@ def setup(api_key: _API_KEY_OPTION, api_host: _API_HOST_OPTION):
     """
     Setup the Hirundo Python SDK.
     """
-    api_host = fix_api_host(api_host)
-    host_location = _location_label(upsert_env("API_HOST", api_host))
-    key_location = _location_label(upsert_env("API_KEY", api_key))
-
-    success(f"API host saved to [bold]{host_location}[/bold].")
-    success(f"API key saved to [bold]{key_location}[/bold].")
-    warn(f"Keep [bold]{key_location}[/bold] private — it contains your secret API key.")
+    _save_api_host(api_host)
+    _save_api_key(api_key)
 
 
 @app.command("check-run", epilog=hirundo_epilog, rich_help_panel=_RUNS_PANEL)

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -4,6 +4,7 @@ import typer
 
 from hirundo._cli_common import (
     ArchivedOption,
+    WaitOption,
     check_run_and_print,
     hirundo_epilog,
     make_app,
@@ -18,12 +19,7 @@ dataset_qa_app = make_app("dataset-qa", "Launch and monitor Dataset QA runs.")
 @dataset_qa_app.command("run", epilog=hirundo_epilog)
 def dataset_qa_run(
     dataset_id: Annotated[int, typer.Argument(help="ID of the dataset to run QA on.")],
-    wait: Annotated[
-        bool,
-        typer.Option(
-            "--wait/--no-wait", help="Wait for the run to complete and stream progress."
-        ),
-    ] = True,
+    wait: WaitOption = True,
 ):
     """
     Launch a Dataset QA run on the dataset with the given ID.

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -1,9 +1,15 @@
 from typing import Annotated
 
 import typer
-from rich.table import Table
 
-from hirundo._cli_common import console, hirundo_epilog, make_app, validate_run_id
+from hirundo._cli_common import (
+    console,
+    hirundo_epilog,
+    make_app,
+    print_runs_table,
+    validate_run_id,
+    wait_or_notify,
+)
 
 dataset_qa_app = make_app("dataset-qa", "Launch and monitor Dataset QA runs.")
 
@@ -26,12 +32,9 @@ def dataset_qa_run(
     run_id = QADataset.launch_qa_run(dataset_id)
     console.print(f"Dataset QA run started. Run ID: [bold]{run_id}[/bold]")
 
-    if wait:
-        QADataset.check_run_by_id(run_id)
-    else:
-        console.print(
-            "Use [bold]hirundo dataset-qa check[/bold] [italic]<run_id>[/italic] to monitor progress."
-        )
+    results = wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
+    if results is not None:
+        console.print(f"Run results saved to {results.cached_zip_path}")
 
 
 @dataset_qa_app.command("list", epilog=hirundo_epilog)
@@ -47,19 +50,20 @@ def dataset_qa_list(
     from hirundo.dataset_qa import QADataset
 
     runs = QADataset.list_runs(archived=archived)
-
-    table = Table(title="Dataset QA Runs:", expand=True)
-    for col in ("Dataset Name", "Run ID", "Status", "Created At", "Run Args"):
-        table.add_column(col, overflow="fold")
-    for run in runs:
-        table.add_row(
-            str(run.name),
-            str(run.run_id),
-            str(run.status),
-            run.created_at.isoformat(),
-            run.run_args.model_dump_json() if run.run_args else None,
-        )
-    console.print(table)
+    print_runs_table(
+        "Dataset QA Runs:",
+        ("Dataset Name", "Run ID", "Status", "Created At", "Run Args"),
+        [
+            (
+                str(run.name),
+                str(run.run_id),
+                str(run.status),
+                run.created_at.isoformat(),
+                run.run_args.model_dump_json() if run.run_args else None,
+            )
+            for run in runs
+        ],
+    )
 
 
 @dataset_qa_app.command("check", epilog=hirundo_epilog)
@@ -71,4 +75,6 @@ def dataset_qa_check(
     """
     from hirundo.dataset_qa import QADataset
 
-    QADataset.check_run_by_id(validate_run_id(run_id))
+    results = QADataset.check_run_by_id(validate_run_id(run_id))
+    if results is not None:
+        console.print(f"Run results saved to {results.cached_zip_path}")

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import typer
 from rich.table import Table
 
-from hirundo._cli_common import console, hirundo_epilog, make_app
+from hirundo._cli_common import console, hirundo_epilog, make_app, validate_run_id
 
 dataset_qa_app = make_app("dataset-qa", "Launch and monitor Dataset QA runs.")
 
@@ -71,4 +71,4 @@ def dataset_qa_check(
     """
     from hirundo.dataset_qa import QADataset
 
-    QADataset.check_run_by_id(run_id)
+    QADataset.check_run_by_id(validate_run_id(run_id))

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -4,10 +4,10 @@ import typer
 
 from hirundo._cli_common import (
     check_run_and_print,
-    console,
     hirundo_epilog,
     make_app,
     print_runs_table,
+    report_run_started,
     wait_or_notify,
 )
 
@@ -30,7 +30,7 @@ def dataset_qa_run(
     from hirundo.dataset_qa import QADataset
 
     run_id = QADataset.launch_qa_run(dataset_id)
-    console.print(f"Dataset QA run started. Run ID: [bold]{run_id}[/bold]")
+    report_run_started("Dataset QA", run_id)
 
     wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
 

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -1,0 +1,96 @@
+"""
+CLI sub-app for Dataset QA commands.
+
+Commands:
+    hirundo dataset-qa run    - Launch a Dataset QA run
+    hirundo dataset-qa list   - List Dataset QA runs
+    hirundo dataset-qa check  - Check the status of a Dataset QA run
+"""
+
+import sys
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+docs = "sphinx" in sys.modules
+dataset_qa_epilog = (
+    None
+    if docs
+    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
+)
+
+console = Console()
+
+dataset_qa_app = typer.Typer(
+    name="dataset-qa",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    epilog=dataset_qa_epilog,
+    help="Launch and monitor Dataset QA runs.",
+)
+
+
+@dataset_qa_app.command("run", epilog=dataset_qa_epilog)
+def dataset_qa_run(
+    dataset_id: Annotated[int, typer.Argument(help="ID of the dataset to run QA on.")],
+    wait: Annotated[
+        bool,
+        typer.Option("--wait/--no-wait", help="Wait for the run to complete and stream progress."),
+    ] = True,
+):
+    """
+    Launch a Dataset QA run on the dataset with the given ID.
+    """
+    from hirundo.dataset_qa import QADataset
+
+    run_id = QADataset.launch_qa_run(dataset_id)
+    console.print(f"Dataset QA run started. Run ID: [bold]{run_id}[/bold]")
+
+    if wait:
+        QADataset.check_run_by_id(run_id)
+    else:
+        console.print(
+            "Use [bold]hirundo dataset-qa check[/bold] [italic]<run_id>[/italic] to monitor progress."
+        )
+
+
+@dataset_qa_app.command("list", epilog=dataset_qa_epilog)
+def dataset_qa_list(
+    archived: Annotated[
+        bool,
+        typer.Option("--archived/--no-archived", help="Include archived runs."),
+    ] = False,
+):
+    """
+    List Dataset QA runs.
+    """
+    from hirundo.dataset_qa import QADataset
+
+    runs = QADataset.list_runs(archived=archived)
+
+    table = Table(title="Dataset QA Runs:", expand=True)
+    for col in ("Dataset Name", "Run ID", "Status", "Created At", "Run Args"):
+        table.add_column(col, overflow="fold")
+    for run in runs:
+        table.add_row(
+            str(run.name),
+            str(run.run_id),
+            str(run.status),
+            run.created_at.isoformat(),
+            run.run_args.model_dump_json() if run.run_args else None,
+        )
+    console.print(table)
+
+
+@dataset_qa_app.command("check", epilog=dataset_qa_epilog)
+def dataset_qa_check(
+    run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
+):
+    """
+    Check the status of a Dataset QA run and stream progress.
+    """
+    from hirundo.dataset_qa import QADataset
+
+    QADataset.check_run_by_id(run_id)

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -32,9 +32,7 @@ def dataset_qa_run(
     run_id = QADataset.launch_qa_run(dataset_id)
     console.print(f"Dataset QA run started. Run ID: [bold]{run_id}[/bold]")
 
-    results = wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
-    if results is not None:
-        console.print(f"Run results saved to {results.cached_zip_path}")
+    wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
 
 
 @dataset_qa_app.command("list", epilog=hirundo_epilog)

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 from hirundo._cli_common import (
+    check_run_and_print,
     console,
     hirundo_epilog,
     make_app,
@@ -75,6 +76,4 @@ def dataset_qa_check(
     """
     from hirundo.dataset_qa import QADataset
 
-    results = QADataset.check_run_by_id(validate_run_id(run_id))
-    if results is not None:
-        console.print(f"Run results saved to {results.cached_zip_path}")
+    check_run_and_print(run_id, QADataset.check_run_by_id)

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -1,38 +1,14 @@
-"""
-CLI sub-app for Dataset QA commands.
-
-Commands:
-    hirundo dataset-qa run    - Launch a Dataset QA run
-    hirundo dataset-qa list   - List Dataset QA runs
-    hirundo dataset-qa check  - Check the status of a Dataset QA run
-"""
-
-import sys
 from typing import Annotated
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
-docs = "sphinx" in sys.modules
-dataset_qa_epilog = (
-    None
-    if docs
-    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
-)
+from hirundo._cli_common import console, hirundo_epilog, make_app
 
-console = Console()
-
-dataset_qa_app = typer.Typer(
-    name="dataset-qa",
-    no_args_is_help=True,
-    rich_markup_mode="rich",
-    epilog=dataset_qa_epilog,
-    help="Launch and monitor Dataset QA runs.",
-)
+dataset_qa_app = make_app("dataset-qa", "Launch and monitor Dataset QA runs.")
 
 
-@dataset_qa_app.command("run", epilog=dataset_qa_epilog)
+@dataset_qa_app.command("run", epilog=hirundo_epilog)
 def dataset_qa_run(
     dataset_id: Annotated[int, typer.Argument(help="ID of the dataset to run QA on.")],
     wait: Annotated[
@@ -56,7 +32,7 @@ def dataset_qa_run(
         )
 
 
-@dataset_qa_app.command("list", epilog=dataset_qa_epilog)
+@dataset_qa_app.command("list", epilog=hirundo_epilog)
 def dataset_qa_list(
     archived: Annotated[
         bool,
@@ -84,7 +60,7 @@ def dataset_qa_list(
     console.print(table)
 
 
-@dataset_qa_app.command("check", epilog=dataset_qa_epilog)
+@dataset_qa_app.command("check", epilog=hirundo_epilog)
 def dataset_qa_check(
     run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
 ):

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 from hirundo._cli_common import (
+    ArchivedOption,
     check_run_and_print,
     hirundo_epilog,
     make_app,
@@ -36,12 +37,7 @@ def dataset_qa_run(
 
 
 @dataset_qa_app.command("list", epilog=hirundo_epilog)
-def dataset_qa_list(
-    archived: Annotated[
-        bool,
-        typer.Option("--archived/--no-archived", help="Include archived runs."),
-    ] = False,
-):
+def dataset_qa_list(archived: ArchivedOption = False):
     """
     List Dataset QA runs.
     """

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -8,7 +8,6 @@ from hirundo._cli_common import (
     hirundo_epilog,
     make_app,
     print_runs_table,
-    validate_run_id,
     wait_or_notify,
 )
 

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -13,7 +13,9 @@ def dataset_qa_run(
     dataset_id: Annotated[int, typer.Argument(help="ID of the dataset to run QA on.")],
     wait: Annotated[
         bool,
-        typer.Option("--wait/--no-wait", help="Wait for the run to complete and stream progress."),
+        typer.Option(
+            "--wait/--no-wait", help="Wait for the run to complete and stream progress."
+        ),
     ] = True,
 ):
     """

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -66,6 +66,9 @@ def eval_run(
         )
         raise typer.Exit(code=1)
 
+    if source_run_id is not None:
+        source_run_id = validate_run_id(source_run_id)
+
     preset_type = validate_enum(preset, PresetType, "preset")
     model_or_run = ModelOrRun.MODEL if model_id is not None else ModelOrRun.RUN
     run_info = EvalRunInfo(

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 from hirundo._cli_common import (
+    check_run_and_print,
     console,
     hirundo_epilog,
     make_app,
@@ -124,6 +125,4 @@ def eval_check(
     """
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
-    results = LlmBehaviorEval.check_run_by_id(validate_run_id(run_id))
-    if results is not None:
-        console.print(f"Run results saved to {results.cached_zip_path}")
+    check_run_and_print(run_id, LlmBehaviorEval.check_run_by_id)

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -1,38 +1,14 @@
-"""
-CLI sub-app for LLM behavior evaluation commands.
-
-Commands:
-    hirundo eval run    - Launch an LLM behavior evaluation run
-    hirundo eval list   - List evaluation runs
-    hirundo eval check  - Check the status of an evaluation run
-"""
-
-import sys
 from typing import Annotated, Optional
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
-docs = "sphinx" in sys.modules
-eval_epilog = (
-    None
-    if docs
-    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
-)
+from hirundo._cli_common import console, hirundo_epilog, make_app, validate_enum
 
-console = Console()
-
-eval_app = typer.Typer(
-    name="eval",
-    no_args_is_help=True,
-    rich_markup_mode="rich",
-    epilog=eval_epilog,
-    help="Launch and monitor LLM behavior evaluation runs.",
-)
+eval_app = make_app("eval", "Launch and monitor LLM behavior evaluation runs.")
 
 
-@eval_app.command("run", epilog=eval_epilog)
+@eval_app.command("run", epilog=hirundo_epilog)
 def eval_run(
     preset: Annotated[
         str,
@@ -72,13 +48,7 @@ def eval_run(
         console.print("[red]Error: only one of --model-id or --source-run-id may be provided.[/red]")
         raise typer.Exit(code=1)
 
-    try:
-        preset_type = PresetType(preset.upper())
-    except ValueError:
-        valid = ", ".join(p.value for p in PresetType)
-        console.print(f"[red]Invalid preset '{preset}'. Valid options: {valid}[/red]")
-        raise typer.Exit(code=1)
-
+    preset_type = validate_enum(preset, PresetType, "preset")
     model_or_run = ModelOrRun.MODEL if model_id is not None else ModelOrRun.RUN
     run_info = EvalRunInfo(
         model_id=model_id,
@@ -98,7 +68,7 @@ def eval_run(
         )
 
 
-@eval_app.command("list", epilog=eval_epilog)
+@eval_app.command("list", epilog=hirundo_epilog)
 def eval_list(
     archived: Annotated[
         bool,
@@ -126,7 +96,7 @@ def eval_list(
     console.print(table)
 
 
-@eval_app.command("check", epilog=eval_epilog)
+@eval_app.command("check", epilog=hirundo_epilog)
 def eval_check(
     run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
 ):

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -31,7 +31,9 @@ def eval_run(
     ] = None,
     wait: Annotated[
         bool,
-        typer.Option("--wait/--no-wait", help="Wait for the run to complete and stream progress."),
+        typer.Option(
+            "--wait/--no-wait", help="Wait for the run to complete and stream progress."
+        ),
     ] = True,
 ):
     """
@@ -47,10 +49,14 @@ def eval_run(
     )
 
     if model_id is None and source_run_id is None:
-        console.print("[red]Error: either --model-id or --source-run-id must be provided.[/red]")
+        console.print(
+            "[red]Error: either --model-id or --source-run-id must be provided.[/red]"
+        )
         raise typer.Exit(code=1)
     if model_id is not None and source_run_id is not None:
-        console.print("[red]Error: only one of --model-id or --source-run-id may be provided.[/red]")
+        console.print(
+            "[red]Error: only one of --model-id or --source-run-id may be provided.[/red]"
+        )
         raise typer.Exit(code=1)
 
     preset_type = validate_enum(preset, PresetType, "preset")

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -1,0 +1,138 @@
+"""
+CLI sub-app for LLM behavior evaluation commands.
+
+Commands:
+    hirundo eval run    - Launch an LLM behavior evaluation run
+    hirundo eval list   - List evaluation runs
+    hirundo eval check  - Check the status of an evaluation run
+"""
+
+import sys
+from typing import Annotated, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+docs = "sphinx" in sys.modules
+eval_epilog = (
+    None
+    if docs
+    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
+)
+
+console = Console()
+
+eval_app = typer.Typer(
+    name="eval",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    epilog=eval_epilog,
+    help="Launch and monitor LLM behavior evaluation runs.",
+)
+
+
+@eval_app.command("run", epilog=eval_epilog)
+def eval_run(
+    preset: Annotated[
+        str,
+        typer.Option(
+            "--preset",
+            help="Evaluation preset. One of: BBQ_BIAS, BBQ_UNBIAS, UNQOVER_BIAS, HALU_EVAL, MED_HALLU, INJECTION_EVAL",
+        ),
+    ],
+    model_id: Annotated[
+        Optional[int],
+        typer.Option("--model-id", help="ID of the LLM model to evaluate."),
+    ] = None,
+    source_run_id: Annotated[
+        Optional[str],
+        typer.Option("--source-run-id", help="ID of the unlearning run to evaluate."),
+    ] = None,
+    name: Annotated[
+        Optional[str],
+        typer.Option("--name", help="Optional name for this evaluation run."),
+    ] = None,
+    wait: Annotated[
+        bool,
+        typer.Option("--wait/--no-wait", help="Wait for the run to complete and stream progress."),
+    ] = True,
+):
+    """
+    Launch an LLM behavior evaluation run.
+
+    Either --model-id or --source-run-id must be provided.
+    """
+    from hirundo.llm_behavior_eval import EvalRunInfo, LlmBehaviorEval, ModelOrRun, PresetType
+
+    if model_id is None and source_run_id is None:
+        console.print("[red]Error: either --model-id or --source-run-id must be provided.[/red]")
+        raise typer.Exit(code=1)
+    if model_id is not None and source_run_id is not None:
+        console.print("[red]Error: only one of --model-id or --source-run-id may be provided.[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        preset_type = PresetType(preset.upper())
+    except ValueError:
+        valid = ", ".join(p.value for p in PresetType)
+        console.print(f"[red]Invalid preset '{preset}'. Valid options: {valid}[/red]")
+        raise typer.Exit(code=1)
+
+    model_or_run = ModelOrRun.MODEL if model_id is not None else ModelOrRun.RUN
+    run_info = EvalRunInfo(
+        model_id=model_id,
+        source_run_id=source_run_id,
+        preset_type=preset_type,
+        name=name,
+    )
+
+    run_id = LlmBehaviorEval.launch_eval_run(model_or_run, run_info)
+    console.print(f"Eval run started. Run ID: [bold]{run_id}[/bold]")
+
+    if wait:
+        LlmBehaviorEval.check_run_by_id(run_id)
+    else:
+        console.print(
+            "Use [bold]hirundo eval check[/bold] [italic]<run_id>[/italic] to monitor progress."
+        )
+
+
+@eval_app.command("list", epilog=eval_epilog)
+def eval_list(
+    archived: Annotated[
+        bool,
+        typer.Option("--archived/--no-archived", help="Include archived runs."),
+    ] = False,
+):
+    """
+    List LLM behavior evaluation runs.
+    """
+    from hirundo.llm_behavior_eval import LlmBehaviorEval
+
+    runs = LlmBehaviorEval.list_runs(archived=archived)
+
+    table = Table(title="Eval Runs:", expand=True)
+    for col in ("Run ID", "Name", "Status", "Preset", "Created At"):
+        table.add_column(col, overflow="fold")
+    for run in runs:
+        table.add_row(
+            str(run.run_id),
+            str(run.name),
+            str(run.status),
+            run.preset_type.value if run.preset_type else None,
+            run.created_at.isoformat(),
+        )
+    console.print(table)
+
+
+@eval_app.command("check", epilog=eval_epilog)
+def eval_check(
+    run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
+):
+    """
+    Check the status of an LLM behavior evaluation run and stream progress.
+    """
+    from hirundo.llm_behavior_eval import LlmBehaviorEval
+
+    LlmBehaviorEval.check_run_by_id(run_id)

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -8,6 +8,7 @@ from hirundo._cli_common import (
     hirundo_epilog,
     make_app,
     print_runs_table,
+    require_exactly_one,
     validate_enum,
     validate_run_id,
     wait_or_notify,
@@ -56,16 +57,7 @@ def eval_run(
         PresetType,
     )
 
-    if model_id is None and source_run_id is None:
-        console.print(
-            "[red]Error: either --model-id or --source-run-id must be provided.[/red]"
-        )
-        raise typer.Exit(code=1)
-    if model_id is not None and source_run_id is not None:
-        console.print(
-            "[red]Error: only one of --model-id or --source-run-id may be provided.[/red]"
-        )
-        raise typer.Exit(code=1)
+    require_exactly_one(("--model-id", model_id), ("--source-run-id", source_run_id))
 
     if source_run_id is not None:
         source_run_id = validate_run_id(source_run_id)

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 from hirundo._cli_common import (
+    ArchivedOption,
     check_run_and_print,
     hirundo_epilog,
     make_app,
@@ -78,12 +79,7 @@ def eval_run(
 
 
 @eval_app.command("list", epilog=hirundo_epilog)
-def eval_list(
-    archived: Annotated[
-        bool,
-        typer.Option("--archived/--no-archived", help="Include archived runs."),
-    ] = False,
-):
+def eval_list(archived: ArchivedOption = False):
     """
     List LLM behavior evaluation runs.
     """

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -4,10 +4,10 @@ import typer
 
 from hirundo._cli_common import (
     check_run_and_print,
-    console,
     hirundo_epilog,
     make_app,
     print_runs_table,
+    report_run_started,
     require_exactly_one,
     validate_enum,
     validate_run_id,
@@ -72,7 +72,7 @@ def eval_run(
     )
 
     run_id = LlmBehaviorEval.launch_eval_run(model_or_run, run_info)
-    console.print(f"Eval run started. Run ID: [bold]{run_id}[/bold]")
+    report_run_started("Eval", run_id)
 
     wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
 

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from rich.table import Table
@@ -18,15 +18,15 @@ def eval_run(
         ),
     ],
     model_id: Annotated[
-        Optional[int],
+        int | None,
         typer.Option("--model-id", help="ID of the LLM model to evaluate."),
     ] = None,
     source_run_id: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--source-run-id", help="ID of the unlearning run to evaluate."),
     ] = None,
     name: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--name", help="Optional name for this evaluation run."),
     ] = None,
     wait: Annotated[
@@ -39,7 +39,12 @@ def eval_run(
 
     Either --model-id or --source-run-id must be provided.
     """
-    from hirundo.llm_behavior_eval import EvalRunInfo, LlmBehaviorEval, ModelOrRun, PresetType
+    from hirundo.llm_behavior_eval import (
+        EvalRunInfo,
+        LlmBehaviorEval,
+        ModelOrRun,
+        PresetType,
+    )
 
     if model_id is None and source_run_id is None:
         console.print("[red]Error: either --model-id or --source-run-id must be provided.[/red]")

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -4,6 +4,7 @@ import typer
 
 from hirundo._cli_common import (
     ArchivedOption,
+    WaitOption,
     check_run_and_print,
     hirundo_epilog,
     make_app,
@@ -39,12 +40,7 @@ def eval_run(
         str | None,
         typer.Option("--name", help="Optional name for this evaluation run."),
     ] = None,
-    wait: Annotated[
-        bool,
-        typer.Option(
-            "--wait/--no-wait", help="Wait for the run to complete and stream progress."
-        ),
-    ] = True,
+    wait: WaitOption = True,
 ):
     """
     Launch an LLM behavior evaluation run.

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -3,7 +3,13 @@ from typing import Annotated
 import typer
 from rich.table import Table
 
-from hirundo._cli_common import console, hirundo_epilog, make_app, validate_enum
+from hirundo._cli_common import (
+    console,
+    hirundo_epilog,
+    make_app,
+    validate_enum,
+    validate_run_id,
+)
 
 eval_app = make_app("eval", "Launch and monitor LLM behavior evaluation runs.")
 
@@ -116,4 +122,4 @@ def eval_check(
     """
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
-    LlmBehaviorEval.check_run_by_id(run_id)
+    LlmBehaviorEval.check_run_by_id(validate_run_id(run_id))

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -1,14 +1,15 @@
 from typing import Annotated
 
 import typer
-from rich.table import Table
 
 from hirundo._cli_common import (
     console,
     hirundo_epilog,
     make_app,
+    print_runs_table,
     validate_enum,
     validate_run_id,
+    wait_or_notify,
 )
 
 eval_app = make_app("eval", "Launch and monitor LLM behavior evaluation runs.")
@@ -77,12 +78,9 @@ def eval_run(
     run_id = LlmBehaviorEval.launch_eval_run(model_or_run, run_info)
     console.print(f"Eval run started. Run ID: [bold]{run_id}[/bold]")
 
-    if wait:
-        LlmBehaviorEval.check_run_by_id(run_id)
-    else:
-        console.print(
-            "Use [bold]hirundo eval check[/bold] [italic]<run_id>[/italic] to monitor progress."
-        )
+    results = wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
+    if results is not None:
+        console.print(f"Run results saved to {results.cached_zip_path}")
 
 
 @eval_app.command("list", epilog=hirundo_epilog)
@@ -98,19 +96,20 @@ def eval_list(
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
     runs = LlmBehaviorEval.list_runs(archived=archived)
-
-    table = Table(title="Eval Runs:", expand=True)
-    for col in ("Run ID", "Name", "Status", "Preset", "Created At"):
-        table.add_column(col, overflow="fold")
-    for run in runs:
-        table.add_row(
-            str(run.run_id),
-            str(run.name),
-            str(run.status),
-            run.preset_type.value if run.preset_type else None,
-            run.created_at.isoformat(),
-        )
-    console.print(table)
+    print_runs_table(
+        "Eval Runs:",
+        ("Run ID", "Name", "Status", "Preset", "Created At"),
+        [
+            (
+                str(run.run_id),
+                str(run.name),
+                str(run.status),
+                run.preset_type.value if run.preset_type else None,
+                run.created_at.isoformat(),
+            )
+            for run in runs
+        ],
+    )
 
 
 @eval_app.command("check", epilog=hirundo_epilog)
@@ -122,4 +121,6 @@ def eval_check(
     """
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
-    LlmBehaviorEval.check_run_by_id(validate_run_id(run_id))
+    results = LlmBehaviorEval.check_run_by_id(validate_run_id(run_id))
+    if results is not None:
+        console.print(f"Run results saved to {results.cached_zip_path}")

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -82,9 +82,7 @@ def eval_run(
     run_id = LlmBehaviorEval.launch_eval_run(model_or_run, run_info)
     console.print(f"Eval run started. Run ID: [bold]{run_id}[/bold]")
 
-    results = wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
-    if results is not None:
-        console.print(f"Run results saved to {results.cached_zip_path}")
+    wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
 
 
 @eval_app.command("list", epilog=hirundo_epilog)

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -3,7 +3,13 @@ from typing import Annotated
 import typer
 from rich.table import Table
 
-from hirundo._cli_common import console, hirundo_epilog, make_app, validate_enum
+from hirundo._cli_common import (
+    console,
+    hirundo_epilog,
+    make_app,
+    validate_enum,
+    validate_run_id,
+)
 
 unlearning_app = make_app("unlearning", "Launch and monitor LLM unlearning runs.")
 
@@ -128,4 +134,4 @@ def unlearning_check(
     """
     from hirundo.unlearning_llm import LlmUnlearningRun
 
-    LlmUnlearningRun.check_run_by_id(run_id)
+    LlmUnlearningRun.check_run_by_id(validate_run_id(run_id))

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -1,38 +1,14 @@
-"""
-CLI sub-app for LLM unlearning commands.
-
-Commands:
-    hirundo unlearning run    - Launch an LLM unlearning run
-    hirundo unlearning list   - List LLM unlearning runs
-    hirundo unlearning check  - Check the status of an LLM unlearning run
-"""
-
-import sys
 from typing import Annotated, Optional
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
-docs = "sphinx" in sys.modules
-unlearning_epilog = (
-    None
-    if docs
-    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
-)
+from hirundo._cli_common import console, hirundo_epilog, make_app, validate_enum
 
-console = Console()
-
-unlearning_app = typer.Typer(
-    name="unlearning",
-    no_args_is_help=True,
-    rich_markup_mode="rich",
-    epilog=unlearning_epilog,
-    help="Launch and monitor LLM unlearning runs.",
-)
+unlearning_app = make_app("unlearning", "Launch and monitor LLM unlearning runs.")
 
 
-@unlearning_app.command("run", epilog=unlearning_epilog)
+@unlearning_app.command("run", epilog=hirundo_epilog)
 def unlearning_run(
     model_id: Annotated[int, typer.Argument(help="ID of the LLM model to unlearn.")],
     bias_type: Annotated[
@@ -85,25 +61,11 @@ def unlearning_run(
         raise typer.Exit(code=1)
 
     if bias_type is not None:
-        try:
-            bias_type_enum = BBQBiasType(bias_type.upper())
-        except ValueError:
-            valid = ", ".join(b.value for b in BBQBiasType)
-            console.print(
-                f"[red]Invalid bias type '{bias_type}'. Valid options: {valid}[/red]"
-            )
-            raise typer.Exit(code=1)
-        target_behavior = BiasBehavior(bias_type=bias_type_enum)
+        target_behavior = BiasBehavior(bias_type=validate_enum(bias_type, BBQBiasType, "bias type"))
     else:
-        try:
-            hallucination_type_enum = HallucinationType(hallucination_type.upper())
-        except ValueError:
-            valid = ", ".join(h.value for h in HallucinationType)
-            console.print(
-                f"[red]Invalid hallucination type '{hallucination_type}'. Valid options: {valid}[/red]"
-            )
-            raise typer.Exit(code=1)
-        target_behavior = HallucinationBehavior(hallucination_type=hallucination_type_enum)
+        target_behavior = HallucinationBehavior(
+            hallucination_type=validate_enum(hallucination_type, HallucinationType, "hallucination type")
+        )
 
     run_info = LlmRunInfo(
         name=name,
@@ -122,7 +84,7 @@ def unlearning_run(
         )
 
 
-@unlearning_app.command("list", epilog=unlearning_epilog)
+@unlearning_app.command("list", epilog=hirundo_epilog)
 def unlearning_list(
     archived: Annotated[
         bool,
@@ -149,7 +111,7 @@ def unlearning_list(
     console.print(table)
 
 
-@unlearning_app.command("check", epilog=unlearning_epilog)
+@unlearning_app.command("check", epilog=hirundo_epilog)
 def unlearning_check(
     run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
 ):

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -9,7 +9,6 @@ from hirundo._cli_common import (
     make_app,
     print_runs_table,
     validate_enum,
-    validate_run_id,
     wait_or_notify,
 )
 

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -4,10 +4,10 @@ import typer
 
 from hirundo._cli_common import (
     check_run_and_print,
-    console,
     hirundo_epilog,
     make_app,
     print_runs_table,
+    report_run_started,
     require_exactly_one,
     validate_enum,
     wait_or_notify,
@@ -81,7 +81,7 @@ def unlearning_run(
     )
 
     run_id = LlmUnlearningRun.launch(model_id, run_info)
-    console.print(f"Unlearning run started. Run ID: [bold]{run_id}[/bold]")
+    report_run_started("Unlearning", run_id)
 
     wait_or_notify(run_id, LlmUnlearningRun.check_run_by_id, "unlearning", wait)
 

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from rich.table import Table
@@ -12,21 +12,21 @@ unlearning_app = make_app("unlearning", "Launch and monitor LLM unlearning runs.
 def unlearning_run(
     model_id: Annotated[int, typer.Argument(help="ID of the LLM model to unlearn.")],
     bias_type: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--bias-type",
             help="Bias type for unlearning. One of: ALL, RACE, NATIONALITY, GENDER, PHYSICAL_APPEARANCE, RELIGION, AGE",
         ),
     ] = None,
     hallucination_type: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--hallucination-type",
             help="Hallucination type for unlearning. One of: GENERAL, MEDICAL, LEGAL, DEFENSE",
         ),
     ] = None,
     name: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--name", help="Optional name for this unlearning run."),
     ] = None,
     wait: Annotated[
@@ -62,10 +62,12 @@ def unlearning_run(
 
     if bias_type is not None:
         target_behavior = BiasBehavior(bias_type=validate_enum(bias_type, BBQBiasType, "bias type"))
-    else:
+    elif hallucination_type is not None:
         target_behavior = HallucinationBehavior(
             hallucination_type=validate_enum(hallucination_type, HallucinationType, "hallucination type")
         )
+    else:
+        raise typer.Exit(code=1) from None
 
     run_info = LlmRunInfo(
         name=name,

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 from hirundo._cli_common import (
+    ArchivedOption,
     check_run_and_print,
     hirundo_epilog,
     make_app,
@@ -87,12 +88,7 @@ def unlearning_run(
 
 
 @unlearning_app.command("list", epilog=hirundo_epilog)
-def unlearning_list(
-    archived: Annotated[
-        bool,
-        typer.Option("--archived/--no-archived", help="Include archived runs."),
-    ] = False,
-):
+def unlearning_list(archived: ArchivedOption = False):
     """
     List LLM unlearning runs.
     """

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -1,14 +1,15 @@
 from typing import Annotated
 
 import typer
-from rich.table import Table
 
 from hirundo._cli_common import (
     console,
     hirundo_epilog,
     make_app,
+    print_runs_table,
     validate_enum,
     validate_run_id,
+    wait_or_notify,
 )
 
 unlearning_app = make_app("unlearning", "Launch and monitor LLM unlearning runs.")
@@ -90,12 +91,7 @@ def unlearning_run(
     run_id = LlmUnlearningRun.launch(model_id, run_info)
     console.print(f"Unlearning run started. Run ID: [bold]{run_id}[/bold]")
 
-    if wait:
-        LlmUnlearningRun.check_run_by_id(run_id)
-    else:
-        console.print(
-            "Use [bold]hirundo unlearning check[/bold] [italic]<run_id>[/italic] to monitor progress."
-        )
+    wait_or_notify(run_id, LlmUnlearningRun.check_run_by_id, "unlearning", wait)
 
 
 @unlearning_app.command("list", epilog=hirundo_epilog)
@@ -111,18 +107,19 @@ def unlearning_list(
     from hirundo.unlearning_llm import LlmUnlearningRun
 
     runs = LlmUnlearningRun.list(archived=archived)
-
-    table = Table(title="Unlearning Runs:", expand=True)
-    for col in ("Name", "Run ID", "Status", "Created At"):
-        table.add_column(col, overflow="fold")
-    for run in runs:
-        table.add_row(
-            str(run.name),
-            str(run.run_id),
-            str(run.status),
-            run.created_at.isoformat(),
-        )
-    console.print(table)
+    print_runs_table(
+        "Unlearning Runs:",
+        ("Name", "Run ID", "Status", "Created At"),
+        [
+            (
+                str(run.name),
+                str(run.run_id),
+                str(run.status),
+                run.created_at.isoformat(),
+            )
+            for run in runs
+        ],
+    )
 
 
 @unlearning_app.command("check", epilog=hirundo_epilog)

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -4,6 +4,7 @@ import typer
 
 from hirundo._cli_common import (
     ArchivedOption,
+    WaitOption,
     check_run_and_print,
     hirundo_epilog,
     make_app,
@@ -38,12 +39,7 @@ def unlearning_run(
         str | None,
         typer.Option("--name", help="Optional name for this unlearning run."),
     ] = None,
-    wait: Annotated[
-        bool,
-        typer.Option(
-            "--wait/--no-wait", help="Wait for the run to complete and stream progress."
-        ),
-    ] = True,
+    wait: WaitOption = True,
 ):
     """
     Launch an LLM unlearning run.

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -31,7 +31,9 @@ def unlearning_run(
     ] = None,
     wait: Annotated[
         bool,
-        typer.Option("--wait/--no-wait", help="Wait for the run to complete and stream progress."),
+        typer.Option(
+            "--wait/--no-wait", help="Wait for the run to complete and stream progress."
+        ),
     ] = True,
 ):
     """
@@ -61,10 +63,14 @@ def unlearning_run(
         raise typer.Exit(code=1)
 
     if bias_type is not None:
-        target_behavior = BiasBehavior(bias_type=validate_enum(bias_type, BBQBiasType, "bias type"))
+        target_behavior = BiasBehavior(
+            bias_type=validate_enum(bias_type, BBQBiasType, "bias type")
+        )
     elif hallucination_type is not None:
         target_behavior = HallucinationBehavior(
-            hallucination_type=validate_enum(hallucination_type, HallucinationType, "hallucination type")
+            hallucination_type=validate_enum(
+                hallucination_type, HallucinationType, "hallucination type"
+            )
         )
     else:
         raise typer.Exit(code=1) from None

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -8,6 +8,7 @@ from hirundo._cli_common import (
     hirundo_epilog,
     make_app,
     print_runs_table,
+    require_exactly_one,
     validate_enum,
     wait_or_notify,
 )
@@ -57,16 +58,9 @@ def unlearning_run(
         LlmUnlearningRun,
     )
 
-    if bias_type is None and hallucination_type is None:
-        console.print(
-            "[red]Error: either --bias-type or --hallucination-type must be provided.[/red]"
-        )
-        raise typer.Exit(code=1)
-    if bias_type is not None and hallucination_type is not None:
-        console.print(
-            "[red]Error: only one of --bias-type or --hallucination-type may be provided.[/red]"
-        )
-        raise typer.Exit(code=1)
+    require_exactly_one(
+        ("--bias-type", bias_type), ("--hallucination-type", hallucination_type)
+    )
 
     if bias_type is not None:
         target_behavior = BiasBehavior(
@@ -78,7 +72,7 @@ def unlearning_run(
                 hallucination_type, HallucinationType, "hallucination type"
             )
         )
-    else:
+    else:  # unreachable: require_exactly_one guarantees one is set
         raise typer.Exit(code=1) from None
 
     run_info = LlmRunInfo(

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -1,0 +1,161 @@
+"""
+CLI sub-app for LLM unlearning commands.
+
+Commands:
+    hirundo unlearning run    - Launch an LLM unlearning run
+    hirundo unlearning list   - List LLM unlearning runs
+    hirundo unlearning check  - Check the status of an LLM unlearning run
+"""
+
+import sys
+from typing import Annotated, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+docs = "sphinx" in sys.modules
+unlearning_epilog = (
+    None
+    if docs
+    else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
+)
+
+console = Console()
+
+unlearning_app = typer.Typer(
+    name="unlearning",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    epilog=unlearning_epilog,
+    help="Launch and monitor LLM unlearning runs.",
+)
+
+
+@unlearning_app.command("run", epilog=unlearning_epilog)
+def unlearning_run(
+    model_id: Annotated[int, typer.Argument(help="ID of the LLM model to unlearn.")],
+    bias_type: Annotated[
+        Optional[str],
+        typer.Option(
+            "--bias-type",
+            help="Bias type for unlearning. One of: ALL, RACE, NATIONALITY, GENDER, PHYSICAL_APPEARANCE, RELIGION, AGE",
+        ),
+    ] = None,
+    hallucination_type: Annotated[
+        Optional[str],
+        typer.Option(
+            "--hallucination-type",
+            help="Hallucination type for unlearning. One of: GENERAL, MEDICAL, LEGAL, DEFENSE",
+        ),
+    ] = None,
+    name: Annotated[
+        Optional[str],
+        typer.Option("--name", help="Optional name for this unlearning run."),
+    ] = None,
+    wait: Annotated[
+        bool,
+        typer.Option("--wait/--no-wait", help="Wait for the run to complete and stream progress."),
+    ] = True,
+):
+    """
+    Launch an LLM unlearning run.
+
+    Exactly one of --bias-type or --hallucination-type must be provided.
+    """
+    from hirundo.llm_bias_type import BBQBiasType
+    from hirundo.unlearning_llm import (
+        BiasBehavior,
+        DefaultUtility,
+        HallucinationBehavior,
+        HallucinationType,
+        LlmRunInfo,
+        LlmUnlearningRun,
+    )
+
+    if bias_type is None and hallucination_type is None:
+        console.print(
+            "[red]Error: either --bias-type or --hallucination-type must be provided.[/red]"
+        )
+        raise typer.Exit(code=1)
+    if bias_type is not None and hallucination_type is not None:
+        console.print(
+            "[red]Error: only one of --bias-type or --hallucination-type may be provided.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if bias_type is not None:
+        try:
+            bias_type_enum = BBQBiasType(bias_type.upper())
+        except ValueError:
+            valid = ", ".join(b.value for b in BBQBiasType)
+            console.print(
+                f"[red]Invalid bias type '{bias_type}'. Valid options: {valid}[/red]"
+            )
+            raise typer.Exit(code=1)
+        target_behavior = BiasBehavior(bias_type=bias_type_enum)
+    else:
+        try:
+            hallucination_type_enum = HallucinationType(hallucination_type.upper())
+        except ValueError:
+            valid = ", ".join(h.value for h in HallucinationType)
+            console.print(
+                f"[red]Invalid hallucination type '{hallucination_type}'. Valid options: {valid}[/red]"
+            )
+            raise typer.Exit(code=1)
+        target_behavior = HallucinationBehavior(hallucination_type=hallucination_type_enum)
+
+    run_info = LlmRunInfo(
+        name=name,
+        target_behaviors=[target_behavior],
+        target_utilities=[DefaultUtility()],
+    )
+
+    run_id = LlmUnlearningRun.launch(model_id, run_info)
+    console.print(f"Unlearning run started. Run ID: [bold]{run_id}[/bold]")
+
+    if wait:
+        LlmUnlearningRun.check_run_by_id(run_id)
+    else:
+        console.print(
+            "Use [bold]hirundo unlearning check[/bold] [italic]<run_id>[/italic] to monitor progress."
+        )
+
+
+@unlearning_app.command("list", epilog=unlearning_epilog)
+def unlearning_list(
+    archived: Annotated[
+        bool,
+        typer.Option("--archived/--no-archived", help="Include archived runs."),
+    ] = False,
+):
+    """
+    List LLM unlearning runs.
+    """
+    from hirundo.unlearning_llm import LlmUnlearningRun
+
+    runs = LlmUnlearningRun.list(archived=archived)
+
+    table = Table(title="Unlearning Runs:", expand=True)
+    for col in ("Name", "Run ID", "Status", "Created At"):
+        table.add_column(col, overflow="fold")
+    for run in runs:
+        table.add_row(
+            str(run.name),
+            str(run.run_id),
+            str(run.status),
+            run.created_at.isoformat(),
+        )
+    console.print(table)
+
+
+@unlearning_app.command("check", epilog=unlearning_epilog)
+def unlearning_check(
+    run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
+):
+    """
+    Check the status of an LLM unlearning run and stream progress.
+    """
+    from hirundo.unlearning_llm import LlmUnlearningRun
+
+    LlmUnlearningRun.check_run_by_id(run_id)

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -51,7 +51,6 @@ def unlearning_run(
     from hirundo.llm_bias_type import BBQBiasType
     from hirundo.unlearning_llm import (
         BiasBehavior,
-        DefaultUtility,
         HallucinationBehavior,
         HallucinationType,
         LlmRunInfo,
@@ -85,7 +84,6 @@ def unlearning_run(
     run_info = LlmRunInfo(
         name=name,
         target_behaviors=[target_behavior],
-        target_utilities=[DefaultUtility()],
     )
 
     run_id = LlmUnlearningRun.launch(model_id, run_info)

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 from hirundo._cli_common import (
+    check_run_and_print,
     console,
     hirundo_epilog,
     make_app,
@@ -129,4 +130,4 @@ def unlearning_check(
     """
     from hirundo.unlearning_llm import LlmUnlearningRun
 
-    LlmUnlearningRun.check_run_by_id(validate_run_id(run_id))
+    check_run_and_print(run_id, LlmUnlearningRun.check_run_by_id)

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+import hirundo._cli_common as cli_common  # noqa: E402
+import pytest
+import typer
+from hirundo._cli_common import validate_run_id, wait_or_notify
+
+
+class TestValidateRunId:
+    def test_valid_id_returned_unchanged(self):
+        assert validate_run_id("abc-123_XYZ") == "abc-123_XYZ"
+
+    @pytest.mark.parametrize(
+        "bad_id", ["run/id", "run\\id", "run id", "run\nid", "run.id", ""]
+    )
+    def test_invalid_id_exits(self, bad_id):
+        with pytest.raises(typer.Exit) as exc:
+            validate_run_id(bad_id)
+        assert exc.value.exit_code == 1
+
+    def test_invalid_id_prints_message(self, bad_id="bad id"):
+        with (
+            patch.object(cli_common.console, "print") as mock_print,
+            pytest.raises(typer.Exit),
+        ):
+            validate_run_id(bad_id)
+        output = mock_print.call_args[0][0]
+        assert "bad id" in output
+        assert "may only contain" in output
+
+
+class TestWaitOrNotify:
+    def test_wait_true_calls_check_fn_and_returns_result(self):
+        check_fn = MagicMock(return_value="result")
+        assert wait_or_notify("run-1", check_fn, "dataset-qa", wait=True) == "result"
+        check_fn.assert_called_once_with("run-1")
+
+    def test_wait_false_returns_none_without_calling_check_fn(self):
+        check_fn = MagicMock()
+        assert wait_or_notify("run-1", check_fn, "dataset-qa", wait=False) is None
+        check_fn.assert_not_called()
+
+    def test_wait_false_prints_check_hint(self):
+        with patch.object(cli_common.console, "print") as mock_print:
+            wait_or_notify("run-1", MagicMock(), "dataset-qa", wait=False)
+        output = mock_print.call_args[0][0]
+        assert "dataset-qa check" in output

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -3,7 +3,37 @@ from unittest.mock import MagicMock, patch
 import hirundo._cli_common as cli_common  # noqa: E402
 import pytest
 import typer
-from hirundo._cli_common import validate_run_id, wait_or_notify
+from hirundo._cli_common import (
+    require_exactly_one,
+    validate_run_id,
+    wait_or_notify,
+)
+
+
+class TestRequireExactlyOne:
+    def test_exactly_one_set_is_ok(self):
+        require_exactly_one(("--a", "x"), ("--b", None))
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            ((("--a", None), ("--b", None))),
+            ((("--a", "x"), ("--b", "y"))),
+        ],
+    )
+    def test_zero_or_many_exits(self, options):
+        with pytest.raises(typer.Exit) as exc:
+            require_exactly_one(*options)
+        assert exc.value.exit_code == 1
+
+    def test_error_message_lists_option_names(self):
+        with (
+            patch.object(cli_common.console, "print") as mock_print,
+            pytest.raises(typer.Exit),
+        ):
+            require_exactly_one(("--a", None), ("--b", None))
+        output = mock_print.call_args[0][0]
+        assert "--a or --b" in output
 
 
 class TestValidateRunId:
@@ -38,12 +68,12 @@ class TestWaitOrNotify:
         check_fn.assert_called_once_with("run-1")
 
     def test_wait_true_prints_results_path_when_present(self):
-        result = MagicMock(cached_zip_path="/tmp/run-1.zip")
+        result = MagicMock(cached_zip_path="cache/run-1.zip")
         check_fn = MagicMock(return_value=result)
         with patch.object(cli_common.console, "print") as mock_print:
             wait_or_notify("run-1", check_fn, "dataset-qa", wait=True)
         printed = " ".join(str(call) for call in mock_print.call_args_list)
-        assert "/tmp/run-1.zip" in printed
+        assert "cache/run-1.zip" in printed
 
     def test_wait_true_no_print_when_results_none(self):
         check_fn = MagicMock(return_value=None)

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -31,9 +31,25 @@ class TestValidateRunId:
 
 class TestWaitOrNotify:
     def test_wait_true_calls_check_fn_and_returns_result(self):
-        check_fn = MagicMock(return_value="result")
-        assert wait_or_notify("run-1", check_fn, "dataset-qa", wait=True) == "result"
+        result = MagicMock(cached_zip_path=None)
+        result.__bool__ = lambda self: True
+        check_fn = MagicMock(return_value=result)
+        assert wait_or_notify("run-1", check_fn, "dataset-qa", wait=True) is result
         check_fn.assert_called_once_with("run-1")
+
+    def test_wait_true_prints_results_path_when_present(self):
+        result = MagicMock(cached_zip_path="/tmp/run-1.zip")
+        check_fn = MagicMock(return_value=result)
+        with patch.object(cli_common.console, "print") as mock_print:
+            wait_or_notify("run-1", check_fn, "dataset-qa", wait=True)
+        printed = " ".join(str(call) for call in mock_print.call_args_list)
+        assert "/tmp/run-1.zip" in printed
+
+    def test_wait_true_no_print_when_results_none(self):
+        check_fn = MagicMock(return_value=None)
+        with patch.object(cli_common.console, "print") as mock_print:
+            wait_or_notify("run-1", check_fn, "dataset-qa", wait=True)
+        mock_print.assert_not_called()
 
     def test_wait_false_returns_none_without_calling_check_fn(self):
         check_fn = MagicMock()


### PR DESCRIPTION
# User description
## Summary
This PR refactors the CLI structure by extracting functionality into separate, modular subcommand modules. The main CLI now delegates to specialized apps for evaluation, unlearning, and dataset QA operations, improving code organization and maintainability.

## Key Changes
- **New `_cli_common.py` module**: Extracted shared CLI utilities including:
  - `console` object for Rich output
  - `hirundo_epilog` configuration
  - `make_app()` helper for creating consistent Typer apps
  - `validate_enum()` helper for enum validation with user-friendly error messages

- **New `cli_eval.py` module**: Extracted evaluation-related commands:
  - `eval run`: Launch LLM behavior evaluation runs with preset configurations
  - `eval list`: List evaluation runs with optional filtering
  - `eval check`: Monitor evaluation run progress

- **New `cli_unlearning.py` module**: Extracted unlearning-related commands:
  - `unlearning run`: Launch LLM unlearning runs (bias or hallucination types)
  - `unlearning list`: List unlearning runs with optional filtering
  - `unlearning check`: Monitor unlearning run progress

- **New `cli_dataset_qa.py` module**: Extracted dataset QA commands:
  - `dataset-qa run`: Launch Dataset QA runs
  - `dataset-qa list`: List Dataset QA runs with optional filtering
  - `dataset-qa check`: Monitor Dataset QA run progress

- **Updated `cli.py`**: 
  - Removed duplicated CLI utilities (moved to `_cli_common.py`)
  - Registered new subcommand apps with the main Typer app
  - Simplified main CLI file to focus on core functionality

## Implementation Details
- All subcommand modules follow a consistent pattern using the `make_app()` helper
- Enum validation is centralized in `validate_enum()` for consistent error handling
- Rich console output is shared across all modules via `_cli_common.console`
- Each subcommand module is self-contained with its own imports and logic
- The main CLI acts as a router, delegating to specialized apps via `add_typer()`

https://claude.ai/code/session_01QGjQJb8G8DM8UaYt66Jewt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it restructures the public CLI surface area by introducing new subcommands and centralized argument validation, which can break existing invocation patterns or expose mismatches in run field names.
> 
> **Overview**
> Refactors the `hirundo` Typer CLI into modular sub-apps and registers new top-level subcommands: `hirundo eval`, `hirundo unlearning`, and `hirundo dataset-qa`.
> 
> Adds `_cli_common.py` to centralize shared CLI setup (`console`, `hirundo_epilog`, `make_app`) and introduces `validate_enum()` for consistent enum parsing and user-friendly failures.
> 
> Implements new `run`/`list`/`check` commands for evaluation, unlearning, and dataset QA, including stricter flag validation (mutual exclusivity/required options) and standardized Rich table output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b375da6420812a7ec4c0cfb80b29bffa4468ec4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactor the Hirundo CLI to delegate evaluation, unlearning, and dataset QA run commands to new <code>cli_eval</code>, <code>cli_unlearning</code>, and <code>cli_dataset_qa</code> Typer apps while the top-level <code>hirundo</code> app routes to them. Centralize shared helpers such as the Rich console output, enum validation, and run formatting so every subcommand reuses consistent epilog and validation behavior from <code>_cli_common.py</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/227?tool=ast&topic=Modular+CLI+cmds>Modular CLI cmds</a>
        </td><td>Delegate the eval, unlearning, and dataset QA flows to new <code>cli_eval</code>, <code>cli_unlearning</code>, and <code>cli_dataset_qa</code> Typer apps while the main CLI registers them under <code>hirundo</code> and reuses their run/list/check commands.<details><summary>Modified files (7)</summary><ul><li>docs/hirundo.cli_dataset_qa.rst</li>
<li>docs/hirundo.cli_eval.rst</li>
<li>docs/hirundo.cli_unlearning.rst</li>
<li>hirundo/cli.py</li>
<li>hirundo/cli_dataset_qa.py</li>
<li>hirundo/cli_eval.py</li>
<li>hirundo/cli_unlearning.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>noreply@anthropic.com</td><td>Fix CI: ruff, basedpyr...</td><td>May 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/227?tool=ast&topic=Shared+CLI+helpers>Shared CLI helpers</a>
        </td><td>Centralize Rich console helpers, enum/run validation, and shared option definitions inside <code>_cli_common</code> and verify them through tests so every module shares consistent behavior.<details><summary>Modified files (2)</summary><ul><li>hirundo/_cli_common.py</li>
<li>tests/test_cli_common.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Extract shared WaitOpt...</td><td>May 30, 2026</td></tr>
<tr><td>noreply@anthropic.com</td><td>refactor(cli): clean u...</td><td>May 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/227?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>