### PR TITLE
Fix SDK Docker image Trivy action

### DIFF
--- a/.github/workflows/deploy-docker-image.yaml
+++ b/.github/workflows/deploy-docker-image.yaml
@@ -86,7 +86,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-trivy-
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.26.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:


### PR DESCRIPTION
# User description
## Summary
- update the Docker image workflow to use an existing Trivy action tag
- unblock on-prem SDK Docker image builds from release tags

## Validation
- verified aquasecurity/trivy-action@v0.36.0 exists via GitHub API

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the Docker image deployment workflow to run <code>aquasecurity/trivy-action@v0.36.0</code> for the Trivy vulnerability-scan step so it uses a published action tag. Ensure the on-prem SDK release pipeline can proceed without blocking on unavailable Trivy releases.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix SDK Docker image T...</td><td>May 26, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>SDK-87: Migrate to `uv...</td><td>February 11, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/228?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>