### PR TITLE
SDK-95: Fix SDK Docker image Trivy action version

### DIFF
--- a/.github/workflows/deploy-docker-image.yaml
+++ b/.github/workflows/deploy-docker-image.yaml
@@ -86,7 +86,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-trivy-
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.26.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:


### PR DESCRIPTION
# User description
## Summary

- Updates `aquasecurity/trivy-action` from `0.26.0` to `v0.36.0` in `.github/workflows/deploy-docker-image.yaml`
- Fixes the `Unable to resolve action aquasecurity/trivy-action@0.26.0, unable to find version 0.26.0` failure that blocked the `v0.2.6.1+on-prem` tag build

## Diff scope

Single-line change: only the Trivy action version pin is updated; no other logic is modified.

## Test plan

- [ ] CI workflow (`deploy-docker-image.yaml`) triggers on this PR (path filter includes the workflow file) and the `build-and-push` job completes successfully with `trivy-action@v0.36.0`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYwojRTnbxMcBAP4xasuBM)_

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>deploy-docker-image</code> workflow's <code>Run Trivy vulnerability scanner</code> step to use the newer <code>aquasecurity/trivy-action</code> release for scanning the SDK Docker image. Ensure the workflow can complete the <code>build-and-push</code> job without failing on the unsupported action version.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix SDK Docker image T...</td><td>May 26, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>SDK-87: Migrate to `uv...</td><td>February 11, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/229?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>