### PR TITLE
SDK-99: CLI --output json, structured errors, stable exit codes (Phase A)

### DIFF
--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -67,12 +67,10 @@ def emit_json(data: Any) -> None:
     sys.stdout.write("\n")
 
 
-def emit(data: Any, render_text: Callable[[], None]) -> None:
-    """Emit ``data`` as JSON in JSON mode, otherwise call ``render_text``."""
+def emit_if_json(data: Any) -> None:
+    """Emit ``data`` as JSON only in JSON mode (no-op in text mode)."""
     if is_json():
         emit_json(data)
-    else:
-        render_text()
 
 
 def success(message: str) -> None:
@@ -206,11 +204,24 @@ def check_run_and_print(run_id: str, check_fn: Callable[[str], Any]) -> Any:
     return _report_results(check_fn(validate_run_id(run_id)))
 
 
-def print_runs_table(
-    title: str,
-    columns: tuple[str, ...],
-    rows: list[tuple[str | None, ...]],
+def _cell(value: Any) -> str | None:
+    """Render a value for a table cell (objects become compact JSON)."""
+    if value is None or isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+def emit_rows(
+    title: str, columns: list[tuple[str, str]], items: list[dict[str, Any]]
 ) -> None:
+    """List output: a JSON array in JSON mode, else a Rich table.
+
+    ``columns`` maps each table header to the item key it renders.
+    """
+    if is_json():
+        emit_json(items)
+        return
+
     table = Table(
         title=title,
         box=box.SIMPLE,
@@ -218,8 +229,8 @@ def print_runs_table(
         show_edge=True,
         header_style="bold",
     )
-    for col in columns:
-        table.add_column(col, overflow="fold")
-    for row in rows:
-        table.add_row(*row)
+    for header, _ in columns:
+        table.add_column(header, overflow="fold")
+    for item in items:
+        table.add_row(*(_cell(item[key]) for _, key in columns))
     console.print(table)

--- a/hirundo/_cli_common.py
+++ b/hirundo/_cli_common.py
@@ -1,13 +1,18 @@
+import json
 import re
 import sys
 from collections.abc import Callable
 from enum import Enum
-from typing import Annotated, Any, TypeAlias
+from typing import Annotated, Any, NoReturn, TypeAlias
 
+import click
 import typer
 from rich import box
 from rich.console import Console
 from rich.table import Table
+from typer.core import TyperGroup
+
+from hirundo._hirundo_error import HirundoError
 
 _RUN_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -18,27 +23,90 @@ hirundo_epilog = (
     else "Made with ❤️ by Hirundo. Visit https://www.hirundo.io for more information."
 )
 
+# Human-facing output goes to stdout in text mode; in JSON mode stdout is
+# reserved for the machine-readable document, so all chatter moves to stderr.
 console = Console()
+err_console = Console(stderr=True)
+
+
+class OutputFormat(str, Enum):
+    text = "text"
+    json = "json"
+
+
+_output_format = OutputFormat.text
+
+
+def set_output_format(fmt: OutputFormat) -> None:
+    global _output_format
+    _output_format = fmt
+
+
+def is_json() -> bool:
+    return _output_format is OutputFormat.json
+
+
+OutputOption: TypeAlias = Annotated[
+    OutputFormat,
+    typer.Option(
+        "--output",
+        "-o",
+        help="Output format. Use 'json' for machine-readable output.",
+    ),
+]
+
+
+def _human_console() -> Console:
+    """Where human-facing chatter goes: stderr in JSON mode, else stdout."""
+    return err_console if is_json() else console
+
+
+def emit_json(data: Any) -> None:
+    """Write a single machine-readable JSON document to stdout."""
+    json.dump(data, sys.stdout, default=str, indent=2)
+    sys.stdout.write("\n")
+
+
+def emit(data: Any, render_text: Callable[[], None]) -> None:
+    """Emit ``data`` as JSON in JSON mode, otherwise call ``render_text``."""
+    if is_json():
+        emit_json(data)
+    else:
+        render_text()
 
 
 def success(message: str) -> None:
     """Print a success message in green."""
-    console.print(f"[green]{message}[/green]")
+    _human_console().print(f"[green]{message}[/green]")
 
 
 def info(message: str) -> None:
     """Print a plain informational message."""
-    console.print(message)
+    _human_console().print(message)
 
 
 def warn(message: str) -> None:
     """Print a warning message in yellow."""
-    console.print(f"[yellow]{message}[/yellow]")
+    _human_console().print(f"[yellow]{message}[/yellow]")
 
 
 def error(message: str) -> None:
-    """Print an error message in red."""
-    console.print(f"[red]{message}[/red]")
+    """Print an error message in red (always to stderr)."""
+    err_console.print(f"[red]{message}[/red]")
+
+
+def _emit_error(message: str) -> None:
+    """Report an error as JSON on stdout (JSON mode) or red on stderr (text)."""
+    if is_json():
+        emit_json({"error": message})
+    else:
+        error(message)
+
+
+def fail(message: str) -> NoReturn:
+    """Report an error and exit with code 1."""
+    _emit_error(message)
+    raise typer.Exit(code=1)
 
 
 ArchivedOption: TypeAlias = Annotated[
@@ -54,9 +122,21 @@ WaitOption: TypeAlias = Annotated[
 ]
 
 
+class HirundoCliGroup(TyperGroup):
+    """Typer group that turns SDK errors into clean CLI output + exit code 1."""
+
+    def invoke(self, ctx: click.Context) -> Any:
+        try:
+            return super().invoke(ctx)
+        except HirundoError as exc:
+            _emit_error(str(exc))
+            raise typer.Exit(code=1) from exc
+
+
 def make_app(name: str, help_text: str) -> typer.Typer:
     return typer.Typer(
         name=name,
+        cls=HirundoCliGroup,
         no_args_is_help=True,
         rich_markup_mode="rich",
         epilog=hirundo_epilog,
@@ -66,11 +146,10 @@ def make_app(name: str, help_text: str) -> typer.Typer:
 
 def validate_run_id(run_id: str) -> str:
     if not _RUN_ID_RE.fullmatch(run_id):
-        error(
+        fail(
             f"Invalid run ID '{run_id}'. Run IDs may only contain "
             "alphanumeric characters, hyphens, and underscores."
         )
-        raise typer.Exit(code=1) from None
     return run_id
 
 
@@ -79,8 +158,7 @@ def validate_enum(value: str, enum_cls: type[Enum], label: str) -> Any:
         return enum_cls(value.upper())
     except ValueError:
         valid = ", ".join(member.value for member in enum_cls)
-        error(f"Invalid {label} '{value}'. Valid options: {valid}.")
-        raise typer.Exit(code=1) from None
+        fail(f"Invalid {label} '{value}'. Valid options: {valid}.")
 
 
 def require_exactly_one(*options: tuple[str, Any]) -> None:
@@ -88,13 +166,22 @@ def require_exactly_one(*options: tuple[str, Any]) -> None:
     provided = [name for name, value in options if value is not None]
     if len(provided) != 1:
         names = " or ".join(name for name, _ in options)
-        error(f"Exactly one of {names} must be provided.")
-        raise typer.Exit(code=1) from None
+        fail(f"Exactly one of {names} must be provided.")
 
 
 def report_run_started(label: str, run_id: str) -> None:
     """Announce a freshly launched run in a consistent style."""
     success(f"{label} run started — Run ID: [bold]{run_id}[/bold]")
+
+
+def _cached_zip_path(results: Any) -> str | None:
+    path = getattr(results, "cached_zip_path", None)
+    return str(path) if path is not None else None
+
+
+def run_payload(run_id: str, results: Any = None) -> dict[str, Any]:
+    """Machine-readable payload describing a run and (optionally) its results."""
+    return {"run_id": run_id, "cached_zip_path": _cached_zip_path(results)}
 
 
 def _report_results(results: Any) -> Any:
@@ -115,8 +202,8 @@ def wait_or_notify(
     return _report_results(check_fn(run_id))
 
 
-def check_run_and_print(run_id: str, check_fn: Callable[[str], Any]) -> None:
-    _report_results(check_fn(validate_run_id(run_id)))
+def check_run_and_print(run_id: str, check_fn: Callable[[str], Any]) -> Any:
+    return _report_results(check_fn(validate_run_id(run_id)))
 
 
 def print_runs_table(

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -11,9 +11,8 @@ from hirundo._cli_common import (
     OutputFormat,
     OutputOption,
     docs,
-    emit_json,
+    emit_if_json,
     hirundo_epilog,
-    is_json,
     set_output_format,
     success,
     warn,
@@ -143,8 +142,7 @@ def setup_api_key(
     """
     set_output_format(output)
     location = _save_api_key(api_key)
-    if is_json():
-        emit_json({"api_key_saved_to": location})
+    emit_if_json({"api_key_saved_to": location})
 
 
 @app.command("change-remote", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
@@ -157,8 +155,7 @@ def change_api_remote(
     """
     set_output_format(output)
     location = _save_api_host(api_host)
-    if is_json():
-        emit_json({"api_host_saved_to": location})
+    emit_if_json({"api_host_saved_to": location})
 
 
 @app.command("setup", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
@@ -173,10 +170,7 @@ def setup(
     set_output_format(output)
     host_location = _save_api_host(api_host)
     key_location = _save_api_key(api_key)
-    if is_json():
-        emit_json(
-            {"api_host_saved_to": host_location, "api_key_saved_to": key_location}
-        )
+    emit_if_json({"api_host_saved_to": host_location, "api_key_saved_to": key_location})
 
 
 @app.command("check-run", epilog=hirundo_epilog, rich_help_panel=_RUNS_PANEL)

--- a/hirundo/cli.py
+++ b/hirundo/cli.py
@@ -6,7 +6,18 @@ from urllib.parse import urlparse
 
 import typer
 
-from hirundo._cli_common import docs, hirundo_epilog, success, warn
+from hirundo._cli_common import (
+    HirundoCliGroup,
+    OutputFormat,
+    OutputOption,
+    docs,
+    emit_json,
+    hirundo_epilog,
+    is_json,
+    set_output_format,
+    success,
+    warn,
+)
 from hirundo._env import API_HOST, EnvLocation
 from hirundo.cli_dataset_qa import dataset_qa_app, dataset_qa_check, dataset_qa_list
 from hirundo.cli_eval import eval_app
@@ -18,6 +29,7 @@ _PIPELINES_PANEL = "Pipelines"
 
 app = typer.Typer(
     name="hirundo",
+    cls=HirundoCliGroup,
     no_args_is_help=True,
     rich_markup_mode="rich",
     epilog=hirundo_epilog,
@@ -105,61 +117,85 @@ def fix_api_host(api_host: str):
     return api_host
 
 
-def _save_api_key(api_key: str) -> None:
+def _save_api_key(api_key: str) -> str:
     location = _location_label(upsert_env("API_KEY", api_key))
     success(f"API key saved to [bold]{location}[/bold].")
     warn(f"Keep [bold]{location}[/bold] private — it contains your secret API key.")
+    return location
 
 
-def _save_api_host(api_host: str) -> None:
+def _save_api_host(api_host: str) -> str:
     location = _location_label(upsert_env("API_HOST", fix_api_host(api_host)))
     success(f"API host saved to [bold]{location}[/bold].")
+    return location
 
 
 @app.command("set-api-key", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
-def setup_api_key(api_key: _API_KEY_OPTION):
+def setup_api_key(
+    api_key: _API_KEY_OPTION,
+    output: OutputOption = OutputFormat.text,
+):
     """
     Save the API key for the Hirundo SDK.
 
     The key is written to a local .env file (or ~/.hirundo.conf if no .env
     exists) and picked up automatically on subsequent commands.
     """
-    _save_api_key(api_key)
+    set_output_format(output)
+    location = _save_api_key(api_key)
+    if is_json():
+        emit_json({"api_key_saved_to": location})
 
 
 @app.command("change-remote", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
-def change_api_remote(api_host: _API_HOST_OPTION):
+def change_api_remote(
+    api_host: _API_HOST_OPTION,
+    output: OutputOption = OutputFormat.text,
+):
     """
     Change the API server address (same URL as the Hirundo web interface).
     """
-    _save_api_host(api_host)
+    set_output_format(output)
+    location = _save_api_host(api_host)
+    if is_json():
+        emit_json({"api_host_saved_to": location})
 
 
 @app.command("setup", epilog=hirundo_epilog, rich_help_panel=_CONFIG_PANEL)
-def setup(api_key: _API_KEY_OPTION, api_host: _API_HOST_OPTION):
+def setup(
+    api_key: _API_KEY_OPTION,
+    api_host: _API_HOST_OPTION,
+    output: OutputOption = OutputFormat.text,
+):
     """
     Setup the Hirundo Python SDK.
     """
-    _save_api_host(api_host)
-    _save_api_key(api_key)
+    set_output_format(output)
+    host_location = _save_api_host(api_host)
+    key_location = _save_api_key(api_key)
+    if is_json():
+        emit_json(
+            {"api_host_saved_to": host_location, "api_key_saved_to": key_location}
+        )
 
 
 @app.command("check-run", epilog=hirundo_epilog, rich_help_panel=_RUNS_PANEL)
 def check_run(
     run_id: str,
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Check the status of a run.
     """
-    dataset_qa_check(run_id)
+    dataset_qa_check(run_id, output)
 
 
 @app.command("list-runs", epilog=hirundo_epilog, rich_help_panel=_RUNS_PANEL)
-def list_runs():
+def list_runs(output: OutputOption = OutputFormat.text):
     """
     List all runs available.
     """
-    dataset_qa_list(archived=False)
+    dataset_qa_list(archived=False, output=output)
 
 
 typer_click_object = typer.main.get_command(app)

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -1,15 +1,23 @@
+import json
 from typing import Annotated
 
 import typer
 
 from hirundo._cli_common import (
     ArchivedOption,
+    OutputFormat,
+    OutputOption,
     WaitOption,
     check_run_and_print,
+    emit,
+    emit_json,
     hirundo_epilog,
+    is_json,
     make_app,
     print_runs_table,
     report_run_started,
+    run_payload,
+    set_output_format,
     wait_or_notify,
 )
 
@@ -20,49 +28,74 @@ dataset_qa_app = make_app("dataset-qa", "Launch and monitor Dataset QA runs.")
 def dataset_qa_run(
     dataset_id: Annotated[int, typer.Argument(help="ID of the dataset to run QA on.")],
     wait: WaitOption = True,
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Launch a Dataset QA run on the dataset with the given ID.
     """
+    set_output_format(output)
     from hirundo.dataset_qa import QADataset
 
     run_id = QADataset.launch_qa_run(dataset_id)
     report_run_started("Dataset QA", run_id)
 
-    wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
+    results = wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
+    if is_json():
+        emit_json(run_payload(run_id, results))
 
 
 @dataset_qa_app.command("list", epilog=hirundo_epilog)
-def dataset_qa_list(archived: ArchivedOption = False):
+def dataset_qa_list(
+    archived: ArchivedOption = False,
+    output: OutputOption = OutputFormat.text,
+):
     """
     List Dataset QA runs.
     """
+    set_output_format(output)
     from hirundo.dataset_qa import QADataset
 
     runs = QADataset.list_runs(archived=archived)
-    print_runs_table(
-        "Dataset QA Runs:",
-        ("Dataset Name", "Run ID", "Status", "Created At", "Run Args"),
-        [
-            (
-                str(run.name),
-                str(run.run_id),
-                str(run.status),
-                run.created_at.isoformat(),
-                run.run_args.model_dump_json() if run.run_args else None,
-            )
-            for run in runs
-        ],
+    items = [
+        {
+            "dataset_name": str(run.name),
+            "run_id": str(run.run_id),
+            "status": str(run.status),
+            "created_at": run.created_at.isoformat(),
+            "run_args": run.run_args.model_dump(mode="json") if run.run_args else None,
+        }
+        for run in runs
+    ]
+    emit(
+        items,
+        lambda: print_runs_table(
+            "Dataset QA Runs:",
+            ("Dataset Name", "Run ID", "Status", "Created At", "Run Args"),
+            [
+                (
+                    item["dataset_name"],
+                    item["run_id"],
+                    item["status"],
+                    item["created_at"],
+                    json.dumps(item["run_args"]) if item["run_args"] else None,
+                )
+                for item in items
+            ],
+        ),
     )
 
 
 @dataset_qa_app.command("check", epilog=hirundo_epilog)
 def dataset_qa_check(
     run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Check the status of a Dataset QA run and stream progress.
     """
+    set_output_format(output)
     from hirundo.dataset_qa import QADataset
 
-    check_run_and_print(run_id, QADataset.check_run_by_id)
+    results = check_run_and_print(run_id, QADataset.check_run_by_id)
+    if is_json():
+        emit_json(run_payload(run_id, results))

--- a/hirundo/cli_dataset_qa.py
+++ b/hirundo/cli_dataset_qa.py
@@ -1,4 +1,3 @@
-import json
 from typing import Annotated
 
 import typer
@@ -9,12 +8,10 @@ from hirundo._cli_common import (
     OutputOption,
     WaitOption,
     check_run_and_print,
-    emit,
-    emit_json,
+    emit_if_json,
+    emit_rows,
     hirundo_epilog,
-    is_json,
     make_app,
-    print_runs_table,
     report_run_started,
     run_payload,
     set_output_format,
@@ -40,8 +37,7 @@ def dataset_qa_run(
     report_run_started("Dataset QA", run_id)
 
     results = wait_or_notify(run_id, QADataset.check_run_by_id, "dataset-qa", wait)
-    if is_json():
-        emit_json(run_payload(run_id, results))
+    emit_if_json(run_payload(run_id, results))
 
 
 @dataset_qa_app.command("list", epilog=hirundo_epilog)
@@ -66,22 +62,16 @@ def dataset_qa_list(
         }
         for run in runs
     ]
-    emit(
+    emit_rows(
+        "Dataset QA Runs:",
+        [
+            ("Dataset Name", "dataset_name"),
+            ("Run ID", "run_id"),
+            ("Status", "status"),
+            ("Created At", "created_at"),
+            ("Run Args", "run_args"),
+        ],
         items,
-        lambda: print_runs_table(
-            "Dataset QA Runs:",
-            ("Dataset Name", "Run ID", "Status", "Created At", "Run Args"),
-            [
-                (
-                    item["dataset_name"],
-                    item["run_id"],
-                    item["status"],
-                    item["created_at"],
-                    json.dumps(item["run_args"]) if item["run_args"] else None,
-                )
-                for item in items
-            ],
-        ),
     )
 
 
@@ -97,5 +87,4 @@ def dataset_qa_check(
     from hirundo.dataset_qa import QADataset
 
     results = check_run_and_print(run_id, QADataset.check_run_by_id)
-    if is_json():
-        emit_json(run_payload(run_id, results))
+    emit_if_json(run_payload(run_id, results))

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -4,13 +4,20 @@ import typer
 
 from hirundo._cli_common import (
     ArchivedOption,
+    OutputFormat,
+    OutputOption,
     WaitOption,
     check_run_and_print,
+    emit,
+    emit_json,
     hirundo_epilog,
+    is_json,
     make_app,
     print_runs_table,
     report_run_started,
     require_exactly_one,
+    run_payload,
+    set_output_format,
     validate_enum,
     validate_run_id,
     wait_or_notify,
@@ -41,12 +48,14 @@ def eval_run(
         typer.Option("--name", help="Optional name for this evaluation run."),
     ] = None,
     wait: WaitOption = True,
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Launch an LLM behavior evaluation run.
 
     Either --model-id or --source-run-id must be provided.
     """
+    set_output_format(output)
     from hirundo.llm_behavior_eval import (
         EvalRunInfo,
         LlmBehaviorEval,
@@ -71,40 +80,63 @@ def eval_run(
     run_id = LlmBehaviorEval.launch_eval_run(model_or_run, run_info)
     report_run_started("Eval", run_id)
 
-    wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
+    results = wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
+    if is_json():
+        emit_json(run_payload(run_id, results))
 
 
 @eval_app.command("list", epilog=hirundo_epilog)
-def eval_list(archived: ArchivedOption = False):
+def eval_list(
+    archived: ArchivedOption = False,
+    output: OutputOption = OutputFormat.text,
+):
     """
     List LLM behavior evaluation runs.
     """
+    set_output_format(output)
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
     runs = LlmBehaviorEval.list_runs(archived=archived)
-    print_runs_table(
-        "Eval Runs:",
-        ("Run ID", "Name", "Status", "Preset", "Created At"),
-        [
-            (
-                str(run.run_id),
-                str(run.name),
-                str(run.status),
-                run.preset_type.value if run.preset_type else None,
-                run.created_at.isoformat(),
-            )
-            for run in runs
-        ],
+    items = [
+        {
+            "run_id": str(run.run_id),
+            "name": str(run.name),
+            "status": str(run.status),
+            "preset": run.preset_type.value if run.preset_type else None,
+            "created_at": run.created_at.isoformat(),
+        }
+        for run in runs
+    ]
+    emit(
+        items,
+        lambda: print_runs_table(
+            "Eval Runs:",
+            ("Run ID", "Name", "Status", "Preset", "Created At"),
+            [
+                (
+                    item["run_id"],
+                    item["name"],
+                    item["status"],
+                    item["preset"],
+                    item["created_at"],
+                )
+                for item in items
+            ],
+        ),
     )
 
 
 @eval_app.command("check", epilog=hirundo_epilog)
 def eval_check(
     run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Check the status of an LLM behavior evaluation run and stream progress.
     """
+    set_output_format(output)
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
-    check_run_and_print(run_id, LlmBehaviorEval.check_run_by_id)
+    results = check_run_and_print(run_id, LlmBehaviorEval.check_run_by_id)
+    if is_json():
+        emit_json(run_payload(run_id, results))

--- a/hirundo/cli_eval.py
+++ b/hirundo/cli_eval.py
@@ -8,12 +8,10 @@ from hirundo._cli_common import (
     OutputOption,
     WaitOption,
     check_run_and_print,
-    emit,
-    emit_json,
+    emit_if_json,
+    emit_rows,
     hirundo_epilog,
-    is_json,
     make_app,
-    print_runs_table,
     report_run_started,
     require_exactly_one,
     run_payload,
@@ -81,8 +79,7 @@ def eval_run(
     report_run_started("Eval", run_id)
 
     results = wait_or_notify(run_id, LlmBehaviorEval.check_run_by_id, "eval", wait)
-    if is_json():
-        emit_json(run_payload(run_id, results))
+    emit_if_json(run_payload(run_id, results))
 
 
 @eval_app.command("list", epilog=hirundo_epilog)
@@ -107,22 +104,16 @@ def eval_list(
         }
         for run in runs
     ]
-    emit(
+    emit_rows(
+        "Eval Runs:",
+        [
+            ("Run ID", "run_id"),
+            ("Name", "name"),
+            ("Status", "status"),
+            ("Preset", "preset"),
+            ("Created At", "created_at"),
+        ],
         items,
-        lambda: print_runs_table(
-            "Eval Runs:",
-            ("Run ID", "Name", "Status", "Preset", "Created At"),
-            [
-                (
-                    item["run_id"],
-                    item["name"],
-                    item["status"],
-                    item["preset"],
-                    item["created_at"],
-                )
-                for item in items
-            ],
-        ),
     )
 
 
@@ -138,5 +129,4 @@ def eval_check(
     from hirundo.llm_behavior_eval import LlmBehaviorEval
 
     results = check_run_and_print(run_id, LlmBehaviorEval.check_run_by_id)
-    if is_json():
-        emit_json(run_payload(run_id, results))
+    emit_if_json(run_payload(run_id, results))

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -4,13 +4,20 @@ import typer
 
 from hirundo._cli_common import (
     ArchivedOption,
+    OutputFormat,
+    OutputOption,
     WaitOption,
     check_run_and_print,
+    emit,
+    emit_json,
     hirundo_epilog,
+    is_json,
     make_app,
     print_runs_table,
     report_run_started,
     require_exactly_one,
+    run_payload,
+    set_output_format,
     validate_enum,
     wait_or_notify,
 )
@@ -40,12 +47,14 @@ def unlearning_run(
         typer.Option("--name", help="Optional name for this unlearning run."),
     ] = None,
     wait: WaitOption = True,
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Launch an LLM unlearning run.
 
     Exactly one of --bias-type or --hallucination-type must be provided.
     """
+    set_output_format(output)
     from hirundo.llm_bias_type import BBQBiasType
     from hirundo.unlearning_llm import (
         BiasBehavior,
@@ -80,39 +89,58 @@ def unlearning_run(
     run_id = LlmUnlearningRun.launch(model_id, run_info)
     report_run_started("Unlearning", run_id)
 
-    wait_or_notify(run_id, LlmUnlearningRun.check_run_by_id, "unlearning", wait)
+    results = wait_or_notify(
+        run_id, LlmUnlearningRun.check_run_by_id, "unlearning", wait
+    )
+    if is_json():
+        emit_json(run_payload(run_id, results))
 
 
 @unlearning_app.command("list", epilog=hirundo_epilog)
-def unlearning_list(archived: ArchivedOption = False):
+def unlearning_list(
+    archived: ArchivedOption = False,
+    output: OutputOption = OutputFormat.text,
+):
     """
     List LLM unlearning runs.
     """
+    set_output_format(output)
     from hirundo.unlearning_llm import LlmUnlearningRun
 
     runs = LlmUnlearningRun.list(archived=archived)
-    print_runs_table(
-        "Unlearning Runs:",
-        ("Name", "Run ID", "Status", "Created At"),
-        [
-            (
-                str(run.name),
-                str(run.run_id),
-                str(run.status),
-                run.created_at.isoformat(),
-            )
-            for run in runs
-        ],
+    items = [
+        {
+            "name": str(run.name),
+            "run_id": str(run.run_id),
+            "status": str(run.status),
+            "created_at": run.created_at.isoformat(),
+        }
+        for run in runs
+    ]
+    emit(
+        items,
+        lambda: print_runs_table(
+            "Unlearning Runs:",
+            ("Name", "Run ID", "Status", "Created At"),
+            [
+                (item["name"], item["run_id"], item["status"], item["created_at"])
+                for item in items
+            ],
+        ),
     )
 
 
 @unlearning_app.command("check", epilog=hirundo_epilog)
 def unlearning_check(
     run_id: Annotated[str, typer.Argument(help="The run ID to check.")],
+    output: OutputOption = OutputFormat.text,
 ):
     """
     Check the status of an LLM unlearning run and stream progress.
     """
+    set_output_format(output)
     from hirundo.unlearning_llm import LlmUnlearningRun
 
-    check_run_and_print(run_id, LlmUnlearningRun.check_run_by_id)
+    results = check_run_and_print(run_id, LlmUnlearningRun.check_run_by_id)
+    if is_json():
+        emit_json(run_payload(run_id, results))

--- a/hirundo/cli_unlearning.py
+++ b/hirundo/cli_unlearning.py
@@ -8,12 +8,10 @@ from hirundo._cli_common import (
     OutputOption,
     WaitOption,
     check_run_and_print,
-    emit,
-    emit_json,
+    emit_if_json,
+    emit_rows,
     hirundo_epilog,
-    is_json,
     make_app,
-    print_runs_table,
     report_run_started,
     require_exactly_one,
     run_payload,
@@ -92,8 +90,7 @@ def unlearning_run(
     results = wait_or_notify(
         run_id, LlmUnlearningRun.check_run_by_id, "unlearning", wait
     )
-    if is_json():
-        emit_json(run_payload(run_id, results))
+    emit_if_json(run_payload(run_id, results))
 
 
 @unlearning_app.command("list", epilog=hirundo_epilog)
@@ -117,16 +114,15 @@ def unlearning_list(
         }
         for run in runs
     ]
-    emit(
+    emit_rows(
+        "Unlearning Runs:",
+        [
+            ("Name", "name"),
+            ("Run ID", "run_id"),
+            ("Status", "status"),
+            ("Created At", "created_at"),
+        ],
         items,
-        lambda: print_runs_table(
-            "Unlearning Runs:",
-            ("Name", "Run ID", "Status", "Created At"),
-            [
-                (item["name"], item["run_id"], item["status"], item["created_at"])
-                for item in items
-            ],
-        ),
     )
 
 
@@ -142,5 +138,4 @@ def unlearning_check(
     from hirundo.unlearning_llm import LlmUnlearningRun
 
     results = check_run_and_print(run_id, LlmUnlearningRun.check_run_by_id)
-    if is_json():
-        emit_json(run_payload(run_id, results))
+    emit_if_json(run_payload(run_id, results))

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -28,7 +28,7 @@ class TestRequireExactlyOne:
 
     def test_error_message_lists_option_names(self):
         with (
-            patch.object(cli_common.console, "print") as mock_print,
+            patch.object(cli_common.err_console, "print") as mock_print,
             pytest.raises(typer.Exit),
         ):
             require_exactly_one(("--a", None), ("--b", None))
@@ -50,7 +50,7 @@ class TestValidateRunId:
 
     def test_invalid_id_prints_message(self, bad_id="bad id"):
         with (
-            patch.object(cli_common.console, "print") as mock_print,
+            patch.object(cli_common.err_console, "print") as mock_print,
             pytest.raises(typer.Exit),
         ):
             validate_run_id(bad_id)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,106 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hirundo import _cli_common
+from hirundo._cli_common import OutputFormat, run_payload, set_output_format
+from hirundo._hirundo_error import HirundoError
+from hirundo.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner(mix_stderr=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_output_format():
+    set_output_format(OutputFormat.text)
+    yield
+    set_output_format(OutputFormat.text)
+
+
+class TestRunPayload:
+    def test_includes_cached_zip_path_when_present(self):
+        results = MagicMock(cached_zip_path="cache/run.zip")
+        assert run_payload("r1", results) == {
+            "run_id": "r1",
+            "cached_zip_path": "cache/run.zip",
+        }
+
+    def test_none_when_results_missing_attr(self):
+        # unlearning returns a raw dict with no cached_zip_path
+        assert run_payload("r1", {"iteration": 1}) == {
+            "run_id": "r1",
+            "cached_zip_path": None,
+        }
+
+    def test_none_when_no_results(self):
+        assert run_payload("r1") == {"run_id": "r1", "cached_zip_path": None}
+
+
+class TestJsonOutput:
+    def test_run_no_wait_emits_clean_json(self):
+        with patch("hirundo.dataset_qa.QADataset") as qa:
+            qa.launch_qa_run.return_value = "run-abc"
+            result = runner.invoke(
+                app, ["dataset-qa", "run", "42", "--no-wait", "-o", "json"]
+            )
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {
+            "run_id": "run-abc",
+            "cached_zip_path": None,
+        }
+
+    def test_list_emits_json_array(self):
+        run = MagicMock(name="ds", run_id="r1", status="COMPLETED", run_args=None)
+        run.name = "ds"
+        run.created_at.isoformat.return_value = "2026-05-31T00:00:00"
+        with patch("hirundo.dataset_qa.QADataset") as qa:
+            qa.list_runs.return_value = [run]
+            result = runner.invoke(app, ["dataset-qa", "list", "-o", "json"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == [
+            {
+                "dataset_name": "ds",
+                "run_id": "r1",
+                "status": "COMPLETED",
+                "created_at": "2026-05-31T00:00:00",
+                "run_args": None,
+            }
+        ]
+
+    def test_sdk_error_emits_json_error_and_exits_1(self):
+        with patch("hirundo.dataset_qa.QADataset") as qa:
+            qa.launch_qa_run.side_effect = HirundoError("boom")
+            result = runner.invoke(app, ["dataset-qa", "run", "42", "-o", "json"])
+        assert result.exit_code == 1
+        assert json.loads(result.stdout) == {"error": "boom"}
+        assert result.stderr == ""
+
+    def test_validation_error_emits_json_error(self):
+        result = runner.invoke(app, ["dataset-qa", "check", "bad/id", "-o", "json"])
+        assert result.exit_code == 1
+        assert "Invalid run ID" in json.loads(result.stdout)["error"]
+
+
+class TestTextOutputUnaffected:
+    def test_error_goes_to_stderr_not_stdout(self):
+        with patch("hirundo.dataset_qa.QADataset") as qa:
+            qa.launch_qa_run.side_effect = HirundoError("boom")
+            result = runner.invoke(app, ["dataset-qa", "run", "42"])
+        assert result.exit_code == 1
+        assert result.stdout == ""
+        assert "boom" in result.stderr
+
+    def test_success_message_on_stdout(self):
+        with patch("hirundo.dataset_qa.QADataset") as qa:
+            qa.launch_qa_run.return_value = "run-abc"
+            result = runner.invoke(app, ["dataset-qa", "run", "42", "--no-wait"])
+        assert result.exit_code == 0
+        assert "run-abc" in result.stdout
+        # no JSON document in text mode
+        assert "{" not in result.stdout
+
+
+def test_human_chatter_routes_to_stderr_in_json_mode():
+    set_output_format(OutputFormat.json)
+    assert _cli_common.is_json() is True


### PR DESCRIPTION
# User description
**Linear:** [SDK-99](https://linear.app/hirundo/issue/SDK-99) (Phase A) · part of epic [SDK-98](https://linear.app/hirundo/issue/SDK-98) · stacked on #227 (SDK-91)

First of the stacked PRs making the CLI agent-usable.

## What this adds
- **`--output/-o [text|json]`** on every command. In JSON mode, **stdout = one machine-readable document**; all human chatter (success/info/warn/error, Rich tables, tqdm progress) is redirected to **stderr**, so an agent can parse stdout directly.
- **Structured output** for `run` (`{run_id, cached_zip_path}`), `list` (array of objects), `check`, the legacy `check-run`/`list-runs`, and the config commands (`{api_*_saved_to}`).
- **`HirundoCliGroup`** converts SDK `HirundoError` into a clean message — `{"error": …}` on stdout in JSON mode — and **exit code 1**. Validation failures (`validate_run_id`, `require_exactly_one`, `validate_enum`) share the same `fail()` path.
- `run_payload()` centralises the `{run_id, cached_zip_path}` shape; `cached_zip_path` is `null` when absent (e.g. unlearning returns a raw dict).

## Scope
**Phase A** of epic **SDK-98**: A (this) → B storage (SDK-100) → C dataset + `dataset-qa run -f` (SDK-101) → D model (SDK-102) → E unlearning/eval run specs (SDK-103) → F discovery (SDK-104). No new resource commands or YAML here — just the machine-readable foundation.

## Tests
`tests/test_cli_output.py` covers the JSON contract (clean stdout, array shape, error→stdout+exit 1, validation→stdout) and text-mode parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implement machine-readable CLI output across the SDK by routing human chatter to stderr, introducing <code>run_payload</code>/<code>emit_rows</code>, and adding the <code>--output/-o</code> option to the dataset QA, eval, unlearning, and config commands. Convert CLI invocation and validation helpers to emit structured JSON errors plus exit 1 so agents see uniform failure payloads while the tests cover the new contract.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/233?tool=ast&topic=Error+Handling>Error Handling</a>
        </td><td>Convert <code>HirundoCliGroup</code> plus validation helpers to emit JSON errors via <code>fail</code> and exit 1, ensuring CLI errors remain machine-readable.<details><summary>Modified files (4)</summary><ul><li>hirundo/_cli_common.py</li>
<li>hirundo/cli.py</li>
<li>tests/test_cli_common.py</li>
<li>tests/test_cli_output.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Simplify PR A: emit_if...</td><td>May 30, 2026</td></tr>
<tr><td>noreply@anthropic.com</td><td>refactor(cli): clean u...</td><td>May 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/233?tool=ast&topic=JSON+Output>JSON Output</a>
        </td><td>Implement JSON output mode by routing chatter to stderr, emitting structured run/list/config payloads via <code>run_payload</code>/<code>emit_rows</code>, and wiring <code>--output/-o</code> across dataset QA, eval, unlearning, and config commands.<details><summary>Modified files (6)</summary><ul><li>hirundo/_cli_common.py</li>
<li>hirundo/cli.py</li>
<li>hirundo/cli_dataset_qa.py</li>
<li>hirundo/cli_eval.py</li>
<li>hirundo/cli_unlearning.py</li>
<li>tests/test_cli_output.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Simplify PR A: emit_if...</td><td>May 30, 2026</td></tr>
<tr><td>noreply@anthropic.com</td><td>refactor(cli): clean u...</td><td>May 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/233?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>