### PR TITLE
SDK-109: Add `suspect_level_counts` field to `DatasetQAResults`

### DIFF
--- a/hirundo/dataset_qa_results.py
+++ b/hirundo/dataset_qa_results.py
@@ -40,7 +40,7 @@ class DatasetQAResults(BaseModel, typing.Generic[T]):
     """
     A polars/pandas DataFrame containing the warnings and errors of the data QA run
     """
-    suspect_level_counts: T | None
+    suspect_level_counts: T | None = None
     """
     A polars/pandas DataFrame containing the suspect level count statistics of the data QA run
     """

--- a/hirundo/dataset_qa_results.py
+++ b/hirundo/dataset_qa_results.py
@@ -40,3 +40,7 @@ class DatasetQAResults(BaseModel, typing.Generic[T]):
     """
     A polars/pandas DataFrame containing the warnings and errors of the data QA run
     """
+    suspect_level_counts: T | None
+    """
+    A polars/pandas DataFrame containing the suspect level count statistics of the data QA run
+    """

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -116,6 +116,26 @@ def get_mislabel_suspect_filename(filenames: list[str]):
     return mislabel_suspect_filename
 
 
+def load_from_zip(zip_path: Path, file_name: str) -> "DataFrameType":
+    """
+    Load a given file from a given zip file.
+
+    Args:
+        zip_path: The path to the zip file.
+        file_name: The name of the file to load.
+
+    Returns:
+        The loaded DataFrame or `None` if neither Polars nor Pandas is available.
+    """
+    with zipfile.ZipFile(zip_path, "r") as z:
+        try:
+            with z.open(file_name) as file:
+                return load_df(file)
+        except Exception as e:
+            logger.error("Failed to load %s from zip file", file_name, exc_info=e)
+    return None
+
+
 def download_and_extract_zip(
     run_id: str, zip_url: str
 ) -> DatasetQAResults[DataFrameType]:
@@ -262,23 +282,3 @@ def download_and_extract_llm_behavior_eval_zip(
             summary_brief=summary_brief_df,
             summary_full=summary_full_df,
         )
-
-
-def load_from_zip(zip_path: Path, file_name: str) -> "DataFrameType":
-    """
-    Load a given file from a given zip file.
-
-    Args:
-        zip_path: The path to the zip file.
-        file_name: The name of the file to load.
-
-    Returns:
-        The loaded DataFrame or `None` if neither Polars nor Pandas is available.
-    """
-    with zipfile.ZipFile(zip_path, "r") as z:
-        try:
-            with z.open(file_name) as file:
-                return load_df(file)
-        except Exception as e:
-            logger.error("Failed to load %s from zip file", file_name, exc_info=e)
-    return None

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -163,64 +163,44 @@ def download_and_extract_zip(
         )
 
         with zipfile.ZipFile(zip_file_path, "r") as z:
-            # Extract suspects file
-            suspects_df = None
-            object_suspects_df = None
-            warnings_and_errors_df = None
-
             filenames = []
             try:
                 filenames = [file.filename for file in z.filelist]
             except Exception as e:
                 logger.error("Failed to get filenames from ZIP", exc_info=e)
 
-            try:
-                mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
-                with z.open(mislabel_suspect_filename) as suspects_file:
-                    suspects_df = load_df(suspects_file)
-                logger.debug(
-                    "Successfully loaded mislabel suspects into DataFrame for run ID %s",
-                    run_id,
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to load mislabel suspects into DataFrame", exc_info=e
-                )
-
-            object_mislabel_suspects_filename = "object_mislabel_suspects.csv"
-            if object_mislabel_suspects_filename in filenames:
+            def _load(filename: str, label: str) -> DataFrameType:
                 try:
-                    with z.open(
-                        object_mislabel_suspects_filename
-                    ) as object_suspects_file:
-                        object_suspects_df = load_df(object_suspects_file)
-                    logger.debug(
-                        "Successfully loaded object mislabel suspects into DataFrame for run ID %s",
-                        run_id,
-                    )
+                    with z.open(filename) as f:
+                        df = load_df(f)
+                    logger.debug("Loaded %s for run ID %s", label, run_id)
+                    return df
                 except Exception as e:
-                    logger.error(
-                        "Failed to load object mislabel suspects into DataFrame",
-                        exc_info=e,
-                    )
+                    logger.error("Failed to load %s", label, exc_info=e)
+                    return None
 
-            try:
-                # Extract warnings_and_errors file
-                with z.open("warnings_and_errors.csv") as warnings_file:
-                    warnings_and_errors_df = load_df(warnings_file)
-                logger.debug(
-                    "Successfully loaded warnings and errors into DataFrame for run ID %s",
-                    run_id,
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to load warnings and errors into DataFrame", exc_info=e
-                )
+            mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
+            suspects_df = _load(mislabel_suspect_filename, "mislabel suspects")
+
+            object_suspects_df = (
+                _load("object_mislabel_suspects.csv", "object mislabel suspects")
+                if "object_mislabel_suspects.csv" in filenames
+                else None
+            )
+
+            suspect_level_counts_df = (
+                _load("mislabel_suspect_level_counts.csv", "suspect level counts")
+                if "mislabel_suspect_level_counts.csv" in filenames
+                else None
+            )
+
+            warnings_and_errors_df = _load("warnings_and_errors.csv", "warnings and errors")
 
             return DatasetQAResults[DataFrameType](
                 cached_zip_path=zip_file_path,
                 suspects=suspects_df,
                 object_suspects=object_suspects_df,
+                suspect_level_counts=suspect_level_counts_df,
                 warnings_and_errors=warnings_and_errors_df,
             )
 

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -171,16 +171,20 @@ def download_and_extract_zip(
 
             def _load(filename: str, label: str) -> DataFrameType:
                 try:
-                    with z.open(filename) as f:
-                        df = load_df(f)
+                    with z.open(filename) as zip_member:
+                        dataframe = load_df(zip_member)
                     logger.debug("Loaded %s for run ID %s", label, run_id)
-                    return df
-                except Exception as e:
-                    logger.error("Failed to load %s", label, exc_info=e)
+                    return dataframe
+                except Exception as exc:
+                    logger.error("Failed to load %s", label, exc_info=exc)
                     return None
 
-            mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
-            suspects_df = _load(mislabel_suspect_filename, "mislabel suspects")
+            try:
+                mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
+                suspects_df = _load(mislabel_suspect_filename, "mislabel suspects")
+            except ValueError as exc:
+                logger.error("Failed to find mislabel suspects file", exc_info=exc)
+                suspects_df = None
 
             object_suspects_df = (
                 _load("object_mislabel_suspects.csv", "object mislabel suspects")
@@ -194,7 +198,9 @@ def download_and_extract_zip(
                 else None
             )
 
-            warnings_and_errors_df = _load("warnings_and_errors.csv", "warnings and errors")
+            warnings_and_errors_df = _load(
+                "warnings_and_errors.csv", "warnings and errors"
+            )
 
             return DatasetQAResults[DataFrameType](
                 cached_zip_path=zip_file_path,

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -162,53 +162,36 @@ def download_and_extract_zip(
             zip_file_path,
         )
 
-        with zipfile.ZipFile(zip_file_path, "r") as z:
-            filenames = []
-            try:
-                filenames = [file.filename for file in z.filelist]
-            except Exception as e:
-                logger.error("Failed to get filenames from ZIP", exc_info=e)
+        filenames = []
+        try:
+            with zipfile.ZipFile(zip_file_path, "r") as zip_file:
+                filenames = zip_file.namelist()
+        except Exception as exc:
+            logger.error("Failed to get filenames from ZIP", exc_info=exc)
 
-            def _load(filename: str, label: str) -> DataFrameType:
-                try:
-                    with z.open(filename) as zip_member:
-                        dataframe = load_df(zip_member)
-                    logger.debug("Loaded %s for run ID %s", label, run_id)
-                    return dataframe
-                except Exception as exc:
-                    logger.error("Failed to load %s", label, exc_info=exc)
-                    return None
-
-            try:
-                mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
-                suspects_df = _load(mislabel_suspect_filename, "mislabel suspects")
-            except ValueError as exc:
-                logger.error("Failed to find mislabel suspects file", exc_info=exc)
-                suspects_df = None
-
-            object_suspects_df = (
-                _load("object_mislabel_suspects.csv", "object mislabel suspects")
-                if "object_mislabel_suspects.csv" in filenames
+        def _load_optional(filename: str) -> DataFrameType:
+            # Only attempt to load files that are present, to avoid noisy error
+            # logs for legitimately-absent optional files (e.g. object suspects).
+            return (
+                load_from_zip(zip_file_path, filename)
+                if filename in filenames
                 else None
             )
 
-            suspect_level_counts_df = (
-                _load("mislabel_suspect_level_counts.csv", "suspect level counts")
-                if "mislabel_suspect_level_counts.csv" in filenames
-                else None
-            )
+        try:
+            mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
+            suspects_df = load_from_zip(zip_file_path, mislabel_suspect_filename)
+        except ValueError as exc:
+            logger.error("Failed to find mislabel suspects file", exc_info=exc)
+            suspects_df = None
 
-            warnings_and_errors_df = _load(
-                "warnings_and_errors.csv", "warnings and errors"
-            )
-
-            return DatasetQAResults[DataFrameType](
-                cached_zip_path=zip_file_path,
-                suspects=suspects_df,
-                object_suspects=object_suspects_df,
-                suspect_level_counts=suspect_level_counts_df,
-                warnings_and_errors=warnings_and_errors_df,
-            )
+        return DatasetQAResults[DataFrameType](
+            cached_zip_path=zip_file_path,
+            suspects=suspects_df,
+            object_suspects=_load_optional("object_mislabel_suspects.csv"),
+            suspect_level_counts=_load_optional("mislabel_suspect_level_counts.csv"),
+            warnings_and_errors=load_from_zip(zip_file_path, "warnings_and_errors.csv"),
+        )
 
 
 def download_and_extract_llm_behavior_eval_zip(
@@ -284,9 +267,7 @@ def download_and_extract_llm_behavior_eval_zip(
         )
 
 
-def load_from_zip(
-    zip_path: Path, file_name: str
-) -> "pd.DataFrame | pl.DataFrame | None":
+def load_from_zip(zip_path: Path, file_name: str) -> "DataFrameType":
     """
     Load a given file from a given zip file.
 

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -124,8 +124,9 @@ def download_and_extract_zip(
 
     Note: It will only extract the `mislabel_suspects.csv` (vision - classification)
     or `image_mislabel_suspects.csv` & `object_mislabel_suspects.csv` (vision - OD)
-    or `suspects.csv` (STT)
-    and `warnings_and_errors.csv` files from the zip file.
+    or `suspects.csv` (STT),
+    plus `mislabel_suspect_level_counts.csv` and `warnings_and_errors.csv`
+    files from the zip file.
 
     Args:
         run_id: The ID of the dataset QA run.
@@ -156,42 +157,38 @@ def download_and_extract_zip(
         with open(zip_file_path, "wb") as output_file:
             for chunk in response.iter_content(chunk_size=ZIP_FILE_CHUNK_SIZE):
                 output_file.write(chunk)
-        logger.info(
-            "Successfully downloaded the result zip file for run ID %s to %s",
-            run_id,
-            zip_file_path,
-        )
+    logger.info(
+        "Successfully downloaded the result zip file for run ID %s to %s",
+        run_id,
+        zip_file_path,
+    )
 
-        filenames = []
-        try:
-            with zipfile.ZipFile(zip_file_path, "r") as zip_file:
-                filenames = zip_file.namelist()
-        except Exception as exc:
-            logger.error("Failed to get filenames from ZIP", exc_info=exc)
+    filenames = []
+    try:
+        with zipfile.ZipFile(zip_file_path, "r") as zip_file:
+            filenames = zip_file.namelist()
+    except Exception as exc:
+        logger.error("Failed to get filenames from ZIP", exc_info=exc)
 
-        def _load_optional(filename: str) -> DataFrameType:
-            # Only attempt to load files that are present, to avoid noisy error
-            # logs for legitimately-absent optional files (e.g. object suspects).
-            return (
-                load_from_zip(zip_file_path, filename)
-                if filename in filenames
-                else None
-            )
+    def _load_optional(filename: str) -> DataFrameType:
+        # Only attempt to load files that are present, to avoid noisy error
+        # logs for legitimately-absent optional files (e.g. object suspects).
+        return load_from_zip(zip_file_path, filename) if filename in filenames else None
 
-        try:
-            mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
-            suspects_df = load_from_zip(zip_file_path, mislabel_suspect_filename)
-        except ValueError as exc:
-            logger.error("Failed to find mislabel suspects file", exc_info=exc)
-            suspects_df = None
+    try:
+        mislabel_suspect_filename = get_mislabel_suspect_filename(filenames)
+        suspects_df = load_from_zip(zip_file_path, mislabel_suspect_filename)
+    except ValueError as exc:
+        logger.error("Failed to find mislabel suspects file", exc_info=exc)
+        suspects_df = None
 
-        return DatasetQAResults[DataFrameType](
-            cached_zip_path=zip_file_path,
-            suspects=suspects_df,
-            object_suspects=_load_optional("object_mislabel_suspects.csv"),
-            suspect_level_counts=_load_optional("mislabel_suspect_level_counts.csv"),
-            warnings_and_errors=load_from_zip(zip_file_path, "warnings_and_errors.csv"),
-        )
+    return DatasetQAResults[DataFrameType](
+        cached_zip_path=zip_file_path,
+        suspects=suspects_df,
+        object_suspects=_load_optional("object_mislabel_suspects.csv"),
+        suspect_level_counts=_load_optional("mislabel_suspect_level_counts.csv"),
+        warnings_and_errors=load_from_zip(zip_file_path, "warnings_and_errors.csv"),
+    )
 
 
 def download_and_extract_llm_behavior_eval_zip(

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -247,38 +247,32 @@ def download_and_extract_llm_behavior_eval_zip(
         with open(zip_file_path, "wb") as output_file:
             for chunk in response.iter_content(chunk_size=ZIP_FILE_CHUNK_SIZE):
                 output_file.write(chunk)
-        logger.info(
-            "Successfully downloaded the LLM behavior eval result zip file for run ID %s to %s",
-            run_id,
-            zip_file_path,
-        )
+    logger.info(
+        "Successfully downloaded the LLM behavior eval result zip file for run ID %s to %s",
+        run_id,
+        zip_file_path,
+    )
 
-        if model_name:
-            model_folder = model_name.split("/")[-1]
-            summary_brief_name = f"responses/{model_folder}/summary_brief.csv"
-            summary_full_name = f"responses/{model_folder}/summary_full.csv"
+    summary_brief_df = None
+    summary_full_df = None
+    if model_name:
+        model_folder = model_name.split("/")[-1]
+        summary_brief_name = f"responses/{model_folder}/summary_brief.csv"
+        summary_full_name = f"responses/{model_folder}/summary_full.csv"
 
-            with zipfile.ZipFile(zip_file_path, "r") as zip_file:
-                filenames = [file.filename for file in zip_file.filelist]
-                if summary_brief_name not in filenames:
-                    raise ValueError(
-                        f"Missing {summary_brief_name} in LLM behavior eval zip for run {run_id}"
-                    )
-                if summary_full_name not in filenames:
-                    raise ValueError(
-                        f"Missing {summary_full_name} in LLM behavior eval zip for run {run_id}"
-                    )
-                with zip_file.open(summary_brief_name) as summary_brief_file:
-                    summary_brief_df = load_df(summary_brief_file)
-                with zip_file.open(summary_full_name) as summary_full_file:
-                    summary_full_df = load_df(summary_full_file)
-        else:
-            summary_brief_df = None
-            summary_full_df = None
+        with zipfile.ZipFile(zip_file_path, "r") as zip_file:
+            filenames = zip_file.namelist()
+        for required_name in (summary_brief_name, summary_full_name):
+            if required_name not in filenames:
+                raise ValueError(
+                    f"Missing {required_name} in LLM behavior eval zip for run {run_id}"
+                )
+        summary_brief_df = load_from_zip(zip_file_path, summary_brief_name)
+        summary_full_df = load_from_zip(zip_file_path, summary_full_name)
 
-        return LlmBehaviorEvalResults[DataFrameType](
-            cached_zip_path=zip_file_path,
-            model_name=model_name,
-            summary_brief=summary_brief_df,
-            summary_full=summary_full_df,
-        )
+    return LlmBehaviorEvalResults[DataFrameType](
+        cached_zip_path=zip_file_path,
+        model_name=model_name,
+        summary_brief=summary_brief_df,
+        summary_full=summary_full_df,
+    )

--- a/tests/unzip_test.py
+++ b/tests/unzip_test.py
@@ -1,0 +1,61 @@
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from hirundo._dataframe import has_pandas, has_polars
+from hirundo.unzip import download_and_extract_zip
+
+SUSPECTS_CSV = "image_path,suspect_level\nimg_0.png,0.9\n"
+SUSPECT_LEVEL_COUNTS_CSV = "suspect_level,count\n0.9,1\n"
+WARNINGS_AND_ERRORS_CSV = "image_path,status\nimg_1.png,MISSING_IMAGE\n"
+
+
+def _build_results_zip() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("mislabel_suspects.csv", SUSPECTS_CSV)
+        archive.writestr("mislabel_suspect_level_counts.csv", SUSPECT_LEVEL_COUNTS_CSV)
+        archive.writestr("warnings_and_errors.csv", WARNINGS_AND_ERRORS_CSV)
+    return buffer.getvalue()
+
+
+class _FakeStreamingResponse:
+    """Minimal stand-in for a streaming `requests` response."""
+
+    def __init__(self, content: bytes):
+        self._content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size: int):
+        yield self._content
+
+
+@pytest.mark.skipif(
+    not (has_pandas or has_polars),
+    reason="Requires pandas or polars to materialize result DataFrames",
+)
+def test_download_and_extract_zip_populates_result_frames(monkeypatch, tmp_path):
+    zip_bytes = _build_results_zip()
+    monkeypatch.setattr(
+        "hirundo.unzip.requests.get",
+        lambda *args, **kwargs: _FakeStreamingResponse(zip_bytes),
+    )
+    # Redirect the cache dir to a temp path so the test never touches the real home.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    results = download_and_extract_zip("test-run-id", "https://example.com/results.zip")
+
+    assert results.suspects is not None
+    assert results.suspect_level_counts is not None
+    assert results.warnings_and_errors is not None
+    # `object_mislabel_suspects.csv` is absent from this ZIP, so it stays None.
+    assert results.object_suspects is None


### PR DESCRIPTION
# User description
## Summary

- Adds `suspect_level_counts: T | None` field to `DatasetQAResults`, loaded from `mislabel_suspect_level_counts.csv` in the result ZIP
- Refactors the repetitive CSV-loading blocks in `download_and_extract_zip()` into a shared `_load()` helper, eliminating ~20 lines of duplication

## Test plan

- [ ] Run a tabular dataset QA job end-to-end and verify `results.suspect_level_counts` is a non-None DataFrame
- [ ] Verify `results.suspect_level_counts` is `None` when the ZIP does not contain `mislabel_suspect_level_counts.csv` (graceful fallback)
- [ ] Existing fields (`suspects`, `object_suspects`, `warnings_and_errors`) still populated correctly

Closes SDK-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>suspect_level_counts</code> handling to <code>DatasetQAResults</code> by loading <code>mislabel_suspect_level_counts.csv</code> from the cached ZIP so the QA results expose the new statistics. Refactor the ZIP download flow by introducing a shared loader that reduces duplication and ensure its behavior with the updated unzip tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/246?tool=ast&topic=Zip+loading+refactor>Zip loading refactor</a>
        </td><td>Refactor the ZIP loading helpers by creating a shared loader used across QA and LLM behavior flows to avoid repetitive CSV parsing logic and centralize error handling.<details><summary>Modified files (1)</summary><ul><li>hirundo/unzip.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Reuse load_from_zip in...</td><td>May 31, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>SDK-79: Add LLM behavi...</td><td>February 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/246?tool=ast&topic=Dataset+QA+data>Dataset QA data</a>
        </td><td>Add <code>suspect_level_counts</code> by wiring <code>mislabel_suspect_level_counts.csv</code> through the ZIP download utilities so <code>DatasetQAResults</code> carries the new statistics alongside the existing suspects and warnings.<details><summary>Modified files (3)</summary><ul><li>hirundo/dataset_qa_results.py</li>
<li>hirundo/unzip.py</li>
<li>tests/unzip_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Reuse load_from_zip in...</td><td>May 31, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>SDK-79: Add LLM behavi...</td><td>February 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/246?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>