### PR TITLE
SDK-111: Include API version for local downloads

### DIFF
--- a/hirundo/_headers.py
+++ b/hirundo/_headers.py
@@ -21,9 +21,15 @@ def _get_api_version_header():
     }
 
 
+def get_auth_api_version_headers():
+    return {
+        **_get_auth_headers(),
+        **_get_api_version_header(),
+    }
+
+
 def get_headers():
     return {
         **_json_headers,
-        **_get_auth_headers(),
-        **_get_api_version_header(),
+        **get_auth_api_version_headers(),
     }

--- a/hirundo/unzip.py
+++ b/hirundo/unzip.py
@@ -18,7 +18,7 @@ from hirundo._dataframe import (
     string,
 )
 from hirundo._env import API_HOST
-from hirundo._headers import _get_auth_headers
+from hirundo._headers import get_auth_api_version_headers
 from hirundo._http import raise_for_status_with_reason, requests
 from hirundo._timeouts import DOWNLOAD_READ_TIMEOUT
 from hirundo.dataset_qa_results import (
@@ -65,7 +65,7 @@ def _download_request(
     local_download_url = (
         f"{API_HOST}/{route_prefix}/run/local-download/?path={quote(local_path)}"
     )
-    return local_download_url, _get_auth_headers()
+    return local_download_url, get_auth_api_version_headers()
 
 
 def _clean_df_index(df: "pd.DataFrame") -> "pd.DataFrame":

--- a/tests/unzip_test.py
+++ b/tests/unzip_test.py
@@ -55,8 +55,11 @@ def test_download_request_converts_dataset_qa_file_url_to_local_download_query(
     monkeypatch.setattr(unzip, "API_HOST", "http://localhost:8000")
     monkeypatch.setattr(
         unzip,
-        "_get_auth_headers",
-        lambda: {"Authorization": "Bearer test-token"},
+        "get_auth_api_version_headers",
+        lambda: {
+            "Authorization": "Bearer test-token",
+            "HIRUNDO-API-VERSION": "0.3",
+        },
     )
 
     zip_url, headers = unzip._download_request(file_url, "dataset-qa")
@@ -65,7 +68,10 @@ def test_download_request_converts_dataset_qa_file_url_to_local_download_query(
         "http://localhost:8000/dataset-qa/run/local-download/"
         "?path=/datasets/results/statlog%20local/run-1/results.zip"
     )
-    assert headers == {"Authorization": "Bearer test-token"}
+    assert headers == {
+        "Authorization": "Bearer test-token",
+        "HIRUNDO-API-VERSION": "0.3",
+    }
 
 
 def test_download_request_leaves_remote_url_unchanged() -> None:


### PR DESCRIPTION
# User description
## Summary

- add a shared auth-plus-API-version header helper
- use that helper for rewritten `file://` local-download artifact requests
- update the unzip regression test to assert local downloads include `HIRUNDO-API-VERSION`

## Tests

- `source .venv/bin/activate && pytest tests/unzip_test.py`
- `source .venv/bin/activate && ruff check hirundo/_headers.py hirundo/unzip.py tests/unzip_test.py`
- `git diff --check`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a shared helper in <code>_headers</code> that composes auth and API version headers for downstream requests. Use that helper in the <code>unzip</code> local download flow so rewritten artifact requests include both authorization and the <code>HIRUNDO-API-VERSION</code> header.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/251?tool=ast&topic=Local+download+test>Local download test</a>
        </td><td>Update local download regression test to assert the <code>HIRUNDO-API-VERSION</code> header is returned alongside authorization.<details><summary>Modified files (1)</summary><ul><li>tests/unzip_test.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>SDK-111: Include API v...</td><td>June 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/251?tool=ast&topic=Local+download+headers>Local download headers</a>
        </td><td>Rework header helpers to compose auth plus API version for local download flows and apply it to <code>_download_request</code> so rewritten URLs carry <code>HIRUNDO-API-VERSION</code>.<details><summary>Modified files (2)</summary><ul><li>hirundo/_headers.py</li>
<li>hirundo/unzip.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>SDK-111: Include API v...</td><td>June 08, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>SDK-79: Add LLM behavi...</td><td>February 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/251?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>