### PR TITLE
v0.2.4

### DIFF
--- a/.github/workflows/deploy-to-pypi.yaml
+++ b/.github/workflows/deploy-to-pypi.yaml
@@ -36,9 +36,11 @@ jobs:
           ${{ github.event.pull_request.body }}
           EOF
 
-          # Use PR title as the tag name; quote to handle spaces
-          git tag -a "${{ github.event.pull_request.title }}" -F .tagmsg.txt
-          git push origin ${{ github.event.pull_request.title }}
+          VERSION=$(python -c "import re; content=open('hirundo/__init__.py').read(); print(re.search(r'__version__ = [\"\\'](.*?)[\"\\']', content).group(1))")
+          TAG_NAME="v${VERSION}"
+
+          git tag -a "${TAG_NAME}" -F .tagmsg.txt
+          git push origin "${TAG_NAME}"
       - name: Install dependencies & build package
         run: |
           uv venv

--- a/hirundo/__init__.py
+++ b/hirundo/__init__.py
@@ -110,4 +110,5 @@ __all__ = [
     "RunStatus",
 ]
 
+# Keep this literal in sync with pyproject.toml; release workflows read it.
 __version__ = "0.2.4"


### PR DESCRIPTION
# User description
Recovery PR for SDK-112 release publishing.

The first v0.2.4 release PR merged, but the PyPI publish job failed before publishing because the workflow used the PR title as the git tag name and the title had been changed to include the SDK key.

This PR makes the publish workflow derive the tag from hirundo.__version__ instead of the PR title, and touches hirundo/__init__.py so the existing pull_request path filter triggers on merge.

On merge, deploy-to-pypi.yaml should create tag v0.2.4 and publish hirundo 0.2.4 to PyPI.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the release workflow with version metadata by deriving the git tag from <code>hirundo.__version__</code> before publishing and pushing that tag to origin. Document that <code>hirundo/__version__</code> is the source of truth so release workflows trigger when merges touch the package version.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/255?tool=ast&topic=Release+tagging>Release tagging</a>
        </td><td>Read <code>hirundo.__version__</code> so the workflow builds a <code>v</code>-prefixed git tag and pushes that tag during the PyPI deploy flow.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/deploy-to-pypi.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>SDK-112: Fix release p...</td><td>June 09, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>SDK-87: Migrate to `uv...</td><td>February 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/255?tool=ast&topic=Version+metadata>Version metadata</a>
        </td><td>Document that <code>hirundo.__version__</code> drives release workflows so the merge path filter picks up version bumps.<details><summary>Modified files (1)</summary><ul><li>hirundo/__init__.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>SDK-112: Fix release p...</td><td>June 09, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>SDK-112: v0.2.4 (#254)</td><td>June 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/255?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>