### PR TITLE
SDK-115: Add timeseries Dataset QA support

### DIFF
--- a/docs/dataset_qa_timeseries_example.py
+++ b/docs/dataset_qa_timeseries_example.py
@@ -1,0 +1,40 @@
+"""Examples for docs/index.rst literalinclude blocks."""
+
+import json
+import os
+
+from hirundo import (
+    HirundoCSV,
+    LabelingType,
+    ModalityType,
+    QADataset,
+    StorageConfig,
+    StorageGCP,
+    StorageTypes,
+)
+
+gcp_bucket = StorageGCP(
+    bucket_name="timeseriesbucket",
+    project="Hirundo-global",
+    credentials_json=json.loads(os.environ["GCP_CREDENTIALS"]),
+)
+
+test_dataset = QADataset(
+    name="TEST-GCP timeseries classification dataset",
+    labeling_type=LabelingType.SINGLE_LABEL_CLASSIFICATION,
+    storage_config=StorageConfig(
+        name="timeseriesbucket",
+        type=StorageTypes.GCP,
+        gcp=gcp_bucket,
+    ),
+    labeling_info=HirundoCSV(
+        csv_url=gcp_bucket.get_url(path="/timeseries/data/metadata.csv"),
+    ),
+    classes=["normal", "anomaly"],
+    modality=ModalityType.TIMESERIES,
+    feature_cols=["sensor_a", "sensor_b", "sensor_c"],
+)
+
+test_dataset.run_qa()
+results = test_dataset.check_run()
+print(results)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ multiple labeling types, including:
 - Object/semantic/panoptic segmentation
 - Speech-to-text
 - Tabular classification
+- Timeseries classification
 
 Supported storage backends include:
 
@@ -83,6 +84,11 @@ Classification example:
 Object detection example:
 
 .. literalinclude:: dataset_qa_object_detection_example.py
+   :language: python
+
+Timeseries example:
+
+.. literalinclude:: dataset_qa_timeseries_example.py
    :language: python
 
 API reference

--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -107,6 +107,7 @@ class ModalityType(str, Enum):
     VISION = "VISION"
     SPEECH = "SPEECH"
     TABULAR = "TABULAR"
+    TIMESERIES = "TIMESERIES"
 
 
 MODALITY_TO_SUPPORTED_LABELING_TYPES = {
@@ -123,7 +124,13 @@ MODALITY_TO_SUPPORTED_LABELING_TYPES = {
     ],
     ModalityType.SPEECH: [LabelingType.SPEECH_TO_TEXT],
     ModalityType.TABULAR: [LabelingType.SINGLE_LABEL_CLASSIFICATION],
+    ModalityType.TIMESERIES: [LabelingType.SINGLE_LABEL_CLASSIFICATION],
 }
+
+
+MODALITIES_WITHOUT_DATA_ROOT = frozenset(
+    (ModalityType.TABULAR, ModalityType.TIMESERIES)
+)
 
 
 class QADataset(BaseModel):
@@ -155,14 +162,19 @@ class QADataset(BaseModel):
     """
     The `StorageConfig` instance to link to.
     """
-    data_root_url: HirundoUrl
+    data_root_url: HirundoUrl | None = None
     """
-    URL for data (e.g. images) within the `StorageConfig` instance,
+    URL for file-backed data (e.g. images or audio) within the `StorageConfig` instance,
     e.g. `s3://my-bucket-name/my-images-folder`, `gs://my-bucket-name/my-images-folder`,
     or `ssh://my-username@my-repo-name/my-images-folder`
     (or `file:///datasets/my-images-folder` if using LOCAL storage type with on-premises installation)
 
-    Note: All CSV `image_path` entries in the metadata file should be relative to this folder.
+    Required for modalities whose metadata references external files. Not used for
+    tabular or timeseries datasets, where the CSV metadata is the dataset itself.
+
+    Note: CSV path columns for file-backed datasets should be relative to this folder.
+    For example, with `data_root_url="s3://my-bucket/images"`, a CSV `image_path`
+    value of `cats/001.jpg` resolves to `s3://my-bucket/images/cats/001.jpg`.
     """
 
     classes: list[str] | None = None
@@ -185,13 +197,13 @@ class QADataset(BaseModel):
     """
     extra_non_feature_cols: list[str] | None = None
     """
-    Tabular classification metadata columns to preserve in compact result exports.
+    Tabular or timeseries classification metadata columns to preserve in compact result exports.
     These columns are passed to core as `learning.dataset.extra_non_feature_cols`
     and are not used as model features.
     """
     feature_cols: list[str] | None = None
     """
-    Tabular classification columns to use as model features.
+    Tabular or timeseries classification columns to use as model features.
     Cannot be provided together with `extra_non_feature_cols`.
     """
 
@@ -204,12 +216,12 @@ class QADataset(BaseModel):
 
     @field_validator("extra_non_feature_cols", "feature_cols", mode="before")
     @classmethod
-    def _normalize_empty_tabular_column_options(cls, value):
+    def _normalize_empty_tabular_like_column_options(cls, value):
         if value == []:
             return None
         return value
 
-    def _validate_tabular_column_options(self) -> None:
+    def _validate_tabular_like_column_options(self) -> None:
         has_extra_non_feature_cols = self.extra_non_feature_cols is not None
         has_feature_cols = self.feature_cols is not None
         if not has_extra_non_feature_cols and not has_feature_cols:
@@ -218,10 +230,21 @@ class QADataset(BaseModel):
             raise ValueError(
                 "Only one of `extra_non_feature_cols` or `feature_cols` can be provided"
             )
-        if self.modality != ModalityType.TABULAR:
+        if self.modality not in MODALITIES_WITHOUT_DATA_ROOT:
             raise ValueError(
-                "`extra_non_feature_cols` and `feature_cols` are only supported for tabular datasets"
+                "`extra_non_feature_cols` and `feature_cols` are only supported for tabular or timeseries datasets"
             )
+
+    def _validate_data_root_url(self) -> None:
+        if (
+            self.data_root_url is None
+            and self.modality not in MODALITIES_WITHOUT_DATA_ROOT
+        ):
+            raise ValueError(
+                "`data_root_url` is required for non-tabular Dataset QA datasets"
+            )
+        if self.data_root_url and self.storage_config:
+            validate_url(self.data_root_url, self.storage_config)
 
     @model_validator(mode="after")
     def validate_dataset(self):
@@ -236,7 +259,7 @@ class QADataset(BaseModel):
             raise ValueError(
                 f"Labeling type {self.labeling_type} is not supported for modality {self.modality}. Supported labeling types are: {MODALITY_TO_SUPPORTED_LABELING_TYPES[self.modality]}"
             )
-        self._validate_tabular_column_options()
+        self._validate_tabular_like_column_options()
         if self.storage_config is None and self.storage_config_id is None:
             raise ValueError(
                 "No dataset storage has been provided. Provide one via `storage_config` or `storage_config_id`"
@@ -275,8 +298,7 @@ class QADataset(BaseModel):
             validate_labeling_info(
                 self.labeling_type, self.labeling_info, self.storage_config
             )
-        if self.data_root_url and self.storage_config:
-            validate_url(self.data_root_url, self.storage_config)
+        self._validate_data_root_url()
         return self
 
     @staticmethod
@@ -443,7 +465,7 @@ class QADataset(BaseModel):
             )
         model_dict = self.model_dump(mode="json", exclude={"storage_config"})
         # ⬆️ Get dict of model fields from Pydantic model instance
-        for optional_key in ("extra_non_feature_cols", "feature_cols"):
+        for optional_key in ("data_root_url", "extra_non_feature_cols", "feature_cols"):
             if model_dict[optional_key] is None:
                 model_dict.pop(optional_key)
         dataset_response = requests.post(
@@ -788,10 +810,12 @@ class QADatasetOut(BaseModel):
 
     name: str
     labeling_type: LabelingType
+    modality: ModalityType = ModalityType.VISION
 
     storage_config: ResponseStorageConfig
+    storage_config_id: int | None = None
 
-    data_root_url: HirundoUrl
+    data_root_url: HirundoUrl | None = None
 
     classes: list[str] | None = None
     labeling_info: LabelingInfo | list[LabelingInfo]
@@ -807,6 +831,7 @@ class DataQARunOut(BaseModel):
     name: str
     dataset_id: int
     run_id: str
+    modality: ModalityType | None = None
     status: RunStatus
     approved: bool
     created_at: datetime.datetime

--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -264,7 +264,14 @@ class QADataset(BaseModel):
             raise ValueError(
                 "No dataset storage has been provided. Provide one via `storage_config` or `storage_config_id`"
             )
-        elif self.storage_config is not None and self.storage_config_id is not None:
+        elif (
+            self.storage_config is not None
+            and self.storage_config_id is not None
+            and (
+                not isinstance(self.storage_config, ResponseStorageConfig)
+                or self.storage_config.id != self.storage_config_id
+            )
+        ):
             raise ValueError(
                 "Both `storage_config` and `storage_config_id` have been provided. Pick one."
             )

--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -246,6 +246,28 @@ class QADataset(BaseModel):
         if self.data_root_url and self.storage_config:
             validate_url(self.data_root_url, self.storage_config)
 
+    def _storage_config_id_matches_response_storage_config(self) -> bool:
+        return (
+            self.storage_config is not None
+            and self.storage_config_id is not None
+            and isinstance(self.storage_config, ResponseStorageConfig)
+            and self.storage_config.id == self.storage_config_id
+        )
+
+    def _ensure_storage_config_consistency(
+        self,
+        missing_message: str,
+        mismatch_message: str,
+    ) -> None:
+        if self.storage_config is None and self.storage_config_id is None:
+            raise ValueError(missing_message)
+        if (
+            self.storage_config is not None
+            and self.storage_config_id is not None
+            and not self._storage_config_id_matches_response_storage_config()
+        ):
+            raise ValueError(mismatch_message)
+
     @model_validator(mode="after")
     def validate_dataset(self):
         if self.modality not in MODALITY_TO_SUPPORTED_LABELING_TYPES:
@@ -260,21 +282,10 @@ class QADataset(BaseModel):
                 f"Labeling type {self.labeling_type} is not supported for modality {self.modality}. Supported labeling types are: {MODALITY_TO_SUPPORTED_LABELING_TYPES[self.modality]}"
             )
         self._validate_tabular_like_column_options()
-        if self.storage_config is None and self.storage_config_id is None:
-            raise ValueError(
-                "No dataset storage has been provided. Provide one via `storage_config` or `storage_config_id`"
-            )
-        elif (
-            self.storage_config is not None
-            and self.storage_config_id is not None
-            and (
-                not isinstance(self.storage_config, ResponseStorageConfig)
-                or self.storage_config.id != self.storage_config_id
-            )
-        ):
-            raise ValueError(
-                "Both `storage_config` and `storage_config_id` have been provided. Pick one."
-            )
+        self._ensure_storage_config_consistency(
+            missing_message="No dataset storage has been provided. Provide one via `storage_config` or `storage_config_id`",
+            mismatch_message="Both `storage_config` and `storage_config_id` have been provided. Pick one.",
+        )
         if self.labeling_type == LabelingType.SPEECH_TO_TEXT and self.language is None:
             raise ValueError("Language is required for Speech-to-Text datasets.")
         elif (
@@ -450,26 +461,17 @@ class QADataset(BaseModel):
         Returns:
             The ID of the created `QADataset` instance
         """
-        if self.storage_config is None and self.storage_config_id is None:
-            raise ValueError("No dataset storage has been provided")
-        elif self.storage_config and self.storage_config_id is None:
+        self._ensure_storage_config_consistency(
+            missing_message="No dataset storage has been provided",
+            mismatch_message="Both `storage_config` and `storage_config_id` have been provided. Storage config IDs do not match.",
+        )
+        if self.storage_config and self.storage_config_id is None:
             if isinstance(self.storage_config, ResponseStorageConfig):
                 self.storage_config_id = self.storage_config.id
             elif isinstance(self.storage_config, StorageConfig):
                 self.storage_config_id = self.storage_config.create(
                     replace_if_exists=replace_if_exists,
                 )
-        elif (
-            self.storage_config is not None
-            and self.storage_config_id is not None
-            and (
-                not isinstance(self.storage_config, ResponseStorageConfig)
-                or self.storage_config.id != self.storage_config_id
-            )
-        ):
-            raise ValueError(
-                "Both `storage_config` and `storage_config_id` have been provided. Storage config IDs do not match."
-            )
         model_dict = self.model_dump(mode="json", exclude={"storage_config"})
         # ⬆️ Get dict of model fields from Pydantic model instance
         for optional_key in ("data_root_url", "extra_non_feature_cols", "feature_cols"):

--- a/tests/test_dataset_qa_config.py
+++ b/tests/test_dataset_qa_config.py
@@ -39,6 +39,23 @@ def _build_dataset_payload(**overrides: Any) -> dict[str, Any]:
     return dataset_payload
 
 
+def _build_storage_config_payload(**overrides: Any) -> dict[str, Any]:
+    storage_config_payload = {
+        "id": 456,
+        "name": "dataset-storage",
+        "type": "GCP",
+        "organization_name": "org",
+        "creator_name": "creator",
+        "s3": None,
+        "gcp": {"bucket_name": "bucket", "project": "project"},
+        "git": None,
+        "created_at": "2026-06-22T14:20:31.663Z",
+        "updated_at": "2026-06-22T14:20:31.663Z",
+    }
+    storage_config_payload.update(overrides)
+    return storage_config_payload
+
+
 def _build_dataset(**overrides: Any) -> QADataset:
     dataset_payload = _build_dataset_payload(
         data_root_url=Url("gs://bucket/data"),
@@ -221,6 +238,25 @@ def test_get_by_id_accepts_empty_tabular_column_options(
     assert dataset.feature_cols is None
 
 
+def test_get_by_name_accepts_matching_storage_config_and_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            _build_dataset_payload(
+                id=123,
+                storage_config_id=456,
+                storage_config=_build_storage_config_payload(id=456),
+            )
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    dataset = QADataset.get_by_name("tabular dataset")
+
+    assert dataset.storage_config_id == 456
+
+
 def test_get_by_id_accepts_timeseries_modality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -253,18 +289,9 @@ def test_list_datasets_accepts_timeseries_modality(
                     id=123,
                     modality=ModalityType.TIMESERIES,
                     data_root_url=None,
-                    storage_config={
-                        "id": 456,
-                        "name": "timeseries-storage",
-                        "type": "GCP",
-                        "organization_name": "org",
-                        "creator_name": "creator",
-                        "s3": None,
-                        "gcp": {"bucket_name": "bucket", "project": "project"},
-                        "git": None,
-                        "created_at": "2026-06-22T14:20:31.663Z",
-                        "updated_at": "2026-06-22T14:20:31.663Z",
-                    },
+                    storage_config=_build_storage_config_payload(
+                        name="timeseries-storage"
+                    ),
                     organization_id=789,
                     creator_id=321,
                     created_at="2026-06-22T14:20:31.663Z",

--- a/tests/test_dataset_qa_config.py
+++ b/tests/test_dataset_qa_config.py
@@ -5,14 +5,21 @@ from hirundo import HirundoCSV, LabelingType, ModalityType, QADataset
 from pydantic_core import Url
 
 
-class _CreateDatasetResponse:
+class _Response:
     status_code = 200
 
-    def json(self) -> dict[str, int]:
-        return {"id": 123}
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+
+    def json(self) -> Any:
+        return self.payload
 
     def raise_for_status(self) -> None:
         return None
+
+
+def _create_dataset_response() -> _Response:
+    return _Response({"id": 123})
 
 
 def _build_dataset_payload(**overrides: Any) -> dict[str, Any]:
@@ -32,20 +39,6 @@ def _build_dataset_payload(**overrides: Any) -> dict[str, Any]:
     return dataset_payload
 
 
-class _GetDatasetResponse:
-    status_code = 200
-
-    def json(self) -> dict[str, Any]:
-        return _build_dataset_payload(
-            id=123,
-            extra_non_feature_cols=[],
-            feature_cols=[],
-        )
-
-    def raise_for_status(self) -> None:
-        return None
-
-
 def _build_dataset(**overrides: Any) -> QADataset:
     dataset_payload = _build_dataset_payload(
         data_root_url=Url("gs://bucket/data"),
@@ -60,9 +53,9 @@ def _capture_create_payload(
 ) -> list[dict[str, Any]]:
     request_payloads: list[dict[str, Any]] = []
 
-    def fake_post(*args: Any, **kwargs: Any) -> _CreateDatasetResponse:
+    def fake_post(*args: Any, **kwargs: Any) -> _Response:
         request_payloads.append(kwargs["json"])
-        return _CreateDatasetResponse()
+        return _create_dataset_response()
 
     monkeypatch.setattr("hirundo.dataset_qa.requests.post", fake_post)
     return request_payloads
@@ -88,6 +81,72 @@ def test_tabular_feature_cols_are_serialized(
     dataset.create()
 
     assert request_payloads[0]["feature_cols"] == ["age", "score"]
+
+
+@pytest.mark.parametrize(
+    "column_option",
+    (
+        {"extra_non_feature_cols": ["sequence_id"]},
+        {"feature_cols": ["temperature", "pressure"]},
+    ),
+)
+def test_timeseries_column_options_are_serialized(
+    monkeypatch: pytest.MonkeyPatch,
+    column_option: dict[str, list[str]],
+) -> None:
+    request_payloads = _capture_create_payload(monkeypatch)
+
+    dataset = _build_dataset(
+        name="timeseries dataset",
+        modality=ModalityType.TIMESERIES,
+        **column_option,
+    )
+    dataset.create()
+
+    option_name = next(iter(column_option))
+    assert request_payloads[0]["modality"] == ModalityType.TIMESERIES
+    assert request_payloads[0][option_name] == column_option[option_name]
+
+
+def test_timeseries_dataset_run_launches_after_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_payloads: list[dict[str, Any] | None] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> _Response:
+        request_payloads.append(kwargs.get("json"))
+        if str(args[0]).endswith("/dataset-qa/run/123"):
+            return _Response({"run_id": "run-123"})
+        return _create_dataset_response()
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.post", fake_post)
+
+    dataset = _build_dataset(modality=ModalityType.TIMESERIES)
+
+    assert dataset.run_qa() == "run-123"
+    assert dataset.run_id == "run-123"
+    create_payload = request_payloads[0]
+    assert create_payload is not None
+    assert create_payload["modality"] == ModalityType.TIMESERIES
+
+
+@pytest.mark.parametrize("modality", (ModalityType.TABULAR, ModalityType.TIMESERIES))
+def test_tabular_like_datasets_can_omit_data_root_url(
+    monkeypatch: pytest.MonkeyPatch,
+    modality: ModalityType,
+) -> None:
+    request_payloads = _capture_create_payload(monkeypatch)
+
+    dataset = _build_dataset(data_root_url=None, modality=modality)
+    dataset.create()
+
+    assert dataset.data_root_url is None
+    assert "data_root_url" not in request_payloads[0]
+
+
+def test_data_root_url_is_required_for_non_tabular_like_datasets() -> None:
+    with pytest.raises(ValueError, match="data_root_url"):
+        _build_dataset(data_root_url=None, modality=ModalityType.VISION)
 
 
 def test_tabular_column_options_default_to_none() -> None:
@@ -126,7 +185,7 @@ def test_tabular_column_options_are_omitted_when_unset(
 def test_tabular_column_options_are_rejected_for_non_tabular_datasets(
     column_option: dict[str, list[str]],
 ) -> None:
-    with pytest.raises(ValueError, match="tabular datasets"):
+    with pytest.raises(ValueError, match="tabular or timeseries datasets"):
         _build_dataset(
             **column_option,
             modality=ModalityType.VISION,
@@ -144,12 +203,107 @@ def test_tabular_column_options_are_mutually_exclusive() -> None:
 def test_get_by_id_accepts_empty_tabular_column_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_get(*args: Any, **kwargs: Any) -> _GetDatasetResponse:
-        return _GetDatasetResponse()
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            _build_dataset_payload(
+                id=123,
+                extra_non_feature_cols=[],
+                feature_cols=[],
+            )
+        )
 
     monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
 
     dataset = QADataset.get_by_id(123)
 
+    assert str(dataset.data_root_url) == "gs://bucket/data"
     assert dataset.extra_non_feature_cols is None
     assert dataset.feature_cols is None
+
+
+def test_get_by_id_accepts_timeseries_modality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            _build_dataset_payload(
+                id=123,
+                modality="TIMESERIES",
+                data_root_url=None,
+                extra_non_feature_cols=["sequence_id"],
+            )
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    dataset = QADataset.get_by_id(123)
+
+    assert dataset.modality == ModalityType.TIMESERIES
+    assert dataset.data_root_url is None
+    assert dataset.extra_non_feature_cols == ["sequence_id"]
+
+
+def test_list_datasets_accepts_timeseries_modality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            [
+                _build_dataset_payload(
+                    id=123,
+                    modality=ModalityType.TIMESERIES,
+                    data_root_url=None,
+                    storage_config={
+                        "id": 456,
+                        "name": "timeseries-storage",
+                        "type": "GCP",
+                        "organization_name": "org",
+                        "creator_name": "creator",
+                        "s3": None,
+                        "gcp": {"bucket_name": "bucket", "project": "project"},
+                        "git": None,
+                        "created_at": "2026-06-22T14:20:31.663Z",
+                        "updated_at": "2026-06-22T14:20:31.663Z",
+                    },
+                    organization_id=789,
+                    creator_id=321,
+                    created_at="2026-06-22T14:20:31.663Z",
+                    updated_at="2026-06-22T14:20:31.663Z",
+                )
+            ]
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    dataset = QADataset.list_datasets()[0]
+
+    assert dataset.modality == ModalityType.TIMESERIES
+    assert dataset.storage_config_id == 456
+    assert dataset.data_root_url is None
+
+
+def test_list_runs_accepts_timeseries_modality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            [
+                {
+                    "id": 1,
+                    "name": "timeseries run",
+                    "dataset_id": 123,
+                    "run_id": "run-123",
+                    "modality": "TIMESERIES",
+                    "status": "PENDING",
+                    "approved": False,
+                    "created_at": "2026-06-22T14:20:31.663Z",
+                    "run_args": None,
+                }
+            ]
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    run = QADataset.list_runs()[0]
+
+    assert run.modality == ModalityType.TIMESERIES


### PR DESCRIPTION
# User description
## Summary
- Add TIMESERIES as a supported Dataset QA modality for single-label classification
- Allow tabular-style feature_cols / extra_non_feature_cols for timeseries datasets
- Preserve timeseries modality when hydrating dataset and run list responses
- Add focused tests and a docs example for timeseries Dataset QA

## Verification
- ruff check .
- ruff format --check .
- basedpyright
- pytest tests/test_dataset_qa_config.py
- pytest tests/test_dataset_qa_config.py tests/unzip_test.py tests/test_iter_sse_retrying.py tests/unlearning-llm/test_bias_behavior_payload.py

## Notes
- Full pytest collection is credential-gated in this worktree: collection fails without AWS_ACCESS_KEY, GCP_CREDENTIALS, HUGGINGFACE_ACCESS_TOKEN, and a valid API key for get_by_name_test.py.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable the Dataset QA flow to treat <code>ModalityType.TIMESERIES</code> like tabular classification by expanding <code>QADataset</code> validation/serialization, run launches, and response hydration to preserve modality-specific data such as feature/extracolumns while honoring storage requirements. Provide a documentation example showing how to configure a timeseries dataset with <code>HirundoCSV</code>, <code>StorageGCP</code>, and <code>feature_cols</code> to run QA programmatically.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/261?tool=ast&topic=Docs+Example>Docs Example</a>
        </td><td>Add a timeseries Dataset QA example that instantiates a <code>StorageGCP</code> config, points <code>HirundoCSV</code> to the metadata, selects <code>feature_cols</code>, and runs QA, and link it from the docs index so users can reference the flow.<details><summary>Modified files (2)</summary><ul><li>docs/dataset_qa_timeseries_example.py</li>
<li>docs/index.rst</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Add timeseries Dataset...</td><td>June 22, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add LLM behavior eval ...</td><td>February 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/261?tool=ast&topic=Timeseries+QA+Flow>Timeseries QA Flow</a>
        </td><td>Enable <code>QADataset</code> to treat <code>ModalityType.TIMESERIES</code> as a tabular-like flow by adding the modality alongside supported labeling types and column options, relaxing <code>data_root_url</code> validation for tabular/timeseries modalities, preserving <code>storage_config</code> IDs, and serializing the new fields when creating/hydrating datasets and runs.<details><summary>Modified files (2)</summary><ul><li>hirundo/dataset_qa.py</li>
<li>tests/test_dataset_qa_config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Deduplicate storage co...</td><td>June 23, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add LLM behavior eval ...</td><td>February 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/261?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>