### PR TITLE
SDK-116: Add multimodal Dataset QA support

### DIFF
--- a/docs/dataset_qa_multimodal_example.py
+++ b/docs/dataset_qa_multimodal_example.py
@@ -1,0 +1,59 @@
+"""Examples for docs/index.rst literalinclude blocks."""
+
+import json
+import os
+
+from hirundo import (
+    HirundoCSV,
+    LabelingType,
+    ModalityType,
+    MultimodalHirundoCSV,
+    MultimodalModalityCSV,
+    MultimodalModalityType,
+    QADataset,
+    StorageConfig,
+    StorageGCP,
+    StorageTypes,
+)
+
+gcp_bucket = StorageGCP(
+    bucket_name="multimodalbucket",
+    project="Hirundo-global",
+    credentials_json=json.loads(os.environ["GCP_CREDENTIALS"]),
+)
+
+test_dataset = QADataset(
+    name="TEST-GCP multimodal classification dataset",
+    labeling_type=LabelingType.SINGLE_LABEL_CLASSIFICATION,
+    storage_config=StorageConfig(
+        name="multimodalbucket",
+        type=StorageTypes.GCP,
+        gcp=gcp_bucket,
+    ),
+    labeling_info=MultimodalHirundoCSV(
+        modality_csvs=[
+            MultimodalModalityCSV(
+                modality=MultimodalModalityType.VISION,
+                labeling_info=HirundoCSV(
+                    csv_url=gcp_bucket.get_url(path="/multimodal/images.csv"),
+                ),
+                data_root_url=gcp_bucket.get_url(path="/multimodal/images"),
+                augmentations=["RandomHorizontalFlip"],
+            ),
+            MultimodalModalityCSV(
+                modality=MultimodalModalityType.TABULAR,
+                labeling_info=HirundoCSV(
+                    csv_url=gcp_bucket.get_url(path="/multimodal/tabular.csv"),
+                ),
+                feature_cols=["height", "width", "score"],
+            ),
+        ],
+        alignment_csv_url=gcp_bucket.get_url(path="/multimodal/alignment.csv"),
+    ),
+    classes=["ok", "defect"],
+    modality=ModalityType.MULTIMODAL,
+)
+
+test_dataset.run_qa()
+results = test_dataset.check_run()
+print(results)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,11 @@ Timeseries example:
 .. literalinclude:: dataset_qa_timeseries_example.py
    :language: python
 
+Multimodal example:
+
+.. literalinclude:: dataset_qa_multimodal_example.py
+   :language: python
+
 API reference
 -------------
 

--- a/hirundo/__init__.py
+++ b/hirundo/__init__.py
@@ -32,6 +32,9 @@ from .labeling import (
     KeylabsObjDetVideo,
     KeylabsObjSegImages,
     KeylabsObjSegVideo,
+    MultimodalHirundoCSV,
+    MultimodalModalityCSV,
+    MultimodalModalityType,
 )
 from .llm_behavior_eval import (
     EvalRunInfo,
@@ -66,6 +69,9 @@ __all__ = [
     "COCO",
     "YOLO",
     "HirundoCSV",
+    "MultimodalHirundoCSV",
+    "MultimodalModalityCSV",
+    "MultimodalModalityType",
     "HirundoError",
     "HirundoDatasetQaError",
     "HirundoLlmBehaviorEvalError",

--- a/hirundo/_column_options.py
+++ b/hirundo/_column_options.py
@@ -1,0 +1,32 @@
+def validate_column_options(
+    *,
+    feature_cols: list[str] | None,
+    extra_non_feature_cols: list[str] | None,
+    modality: object,
+    allowed_modalities: frozenset[object],
+    unsupported_message: str,
+) -> None:
+    """Validate mutually exclusive Dataset QA column mode options.
+
+    Args:
+        feature_cols: Feature column names selected for model input, if provided.
+        extra_non_feature_cols: Non-feature column names to preserve in outputs, if provided.
+        modality: Dataset or child modality being validated.
+        allowed_modalities: Modalities that support column mode options.
+        unsupported_message: Error message to use when column options are provided
+            for an unsupported modality.
+
+    Returns:
+        None. Raises ValueError when both column modes are provided or the modality
+        does not support column mode options.
+    """
+    has_feature_cols = feature_cols is not None
+    has_extra_non_feature_cols = extra_non_feature_cols is not None
+    if not has_feature_cols and not has_extra_non_feature_cols:
+        return
+    if has_feature_cols and has_extra_non_feature_cols:
+        raise ValueError(
+            "Only one of `feature_cols` or `extra_non_feature_cols` can be provided"
+        )
+    if modality not in allowed_modalities:
+        raise ValueError(unsupported_message)

--- a/hirundo/_constraints.py
+++ b/hirundo/_constraints.py
@@ -6,7 +6,7 @@ from hirundo._urls import (
     STORAGE_PATTERNS,
 )
 from hirundo.dataset_enum import DatasetMetadataType, LabelingType, StorageTypes
-from hirundo.labeling import COCO, YOLO, HirundoCSV, Keylabs
+from hirundo.labeling import COCO, YOLO, HirundoCSV, Keylabs, MultimodalHirundoCSV
 
 if TYPE_CHECKING:
     from hirundo._urls import HirundoUrl
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 LABELING_TYPES_TO_DATASET_METADATA_TYPES = {
     LabelingType.SINGLE_LABEL_CLASSIFICATION: [
         DatasetMetadataType.HIRUNDO_CSV,
+        DatasetMetadataType.MULTIMODAL_HIRUNDO_CSV,
     ],
     LabelingType.OBJECT_DETECTION: [
         DatasetMetadataType.HIRUNDO_CSV,
@@ -132,6 +133,18 @@ def validate_labeling_type(
         )
 
 
+def _validate_multimodal_labeling_info_urls(
+    labeling_info: MultimodalHirundoCSV,
+    storage_config: "StorageConfig | ResponseStorageConfig",
+) -> None:
+    for modality_csv in labeling_info.modality_csvs:
+        validate_url(modality_csv.labeling_info.csv_url, storage_config)
+        if modality_csv.data_root_url is not None:
+            validate_url(modality_csv.data_root_url, storage_config)
+    if labeling_info.alignment_csv_url is not None:
+        validate_url(labeling_info.alignment_csv_url, storage_config)
+
+
 def validate_labeling_info(
     labeling_type: "LabelingType",
     labeling_info: "LabelingInfo | list[LabelingInfo]",
@@ -152,6 +165,8 @@ def validate_labeling_info(
         return
     elif isinstance(labeling_info, HirundoCSV):
         validate_url(labeling_info.csv_url, storage_config)
+    elif isinstance(labeling_info, MultimodalHirundoCSV):
+        _validate_multimodal_labeling_info_urls(labeling_info, storage_config)
     elif isinstance(labeling_info, COCO):
         validate_url(labeling_info.json_url, storage_config)
     elif isinstance(labeling_info, YOLO):

--- a/hirundo/dataset_enum.py
+++ b/hirundo/dataset_enum.py
@@ -22,6 +22,7 @@ class DatasetMetadataType(str, Enum):
     """
 
     HIRUNDO_CSV = "HirundoCSV"
+    MULTIMODAL_HIRUNDO_CSV = "MultimodalHirundoCSV"
     COCO = "COCO"
     YOLO = "YOLO"
     HuggingFaceAudio = "HuggingFaceAudio"

--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
+from hirundo._column_options import validate_column_options
 from hirundo._constraints import validate_labeling_info, validate_url
 from hirundo._env import API_HOST
 from hirundo._headers import get_headers
@@ -27,7 +28,12 @@ from hirundo._timeouts import MODIFY_TIMEOUT, READ_TIMEOUT
 from hirundo._urls import HirundoUrl
 from hirundo.dataset_enum import DatasetMetadataType, LabelingType
 from hirundo.dataset_qa_results import DatasetQAResults
-from hirundo.labeling import YOLO, LabelingInfo
+from hirundo.labeling import (
+    YOLO,
+    LabelingInfo,
+    MultimodalHirundoCSV,
+    MultimodalModalityType,
+)
 from hirundo.logger import get_logger
 from hirundo.storage import ResponseStorageConfig, StorageConfig
 from hirundo.unzip import download_and_extract_zip
@@ -100,6 +106,8 @@ class AugmentationName(str, Enum):
     GAUSSIAN_NOISE = "GaussianNoise"
     RANDOM_GRAYSCALE = "RandomGrayscale"
     GAUSSIAN_BLUR = "GaussianBlur"
+    ADD_GAUSSIAN_NOISE = "AddGaussianNoise"
+    MASK_FEATURES = "MaskFeatures"
 
 
 class ModalityType(str, Enum):
@@ -107,6 +115,7 @@ class ModalityType(str, Enum):
     VISION = "VISION"
     SPEECH = "SPEECH"
     TABULAR = "TABULAR"
+    MULTIMODAL = "MULTIMODAL"
     TIMESERIES = "TIMESERIES"
 
 
@@ -124,12 +133,19 @@ MODALITY_TO_SUPPORTED_LABELING_TYPES = {
     ],
     ModalityType.SPEECH: [LabelingType.SPEECH_TO_TEXT],
     ModalityType.TABULAR: [LabelingType.SINGLE_LABEL_CLASSIFICATION],
+    ModalityType.MULTIMODAL: [LabelingType.SINGLE_LABEL_CLASSIFICATION],
     ModalityType.TIMESERIES: [LabelingType.SINGLE_LABEL_CLASSIFICATION],
 }
 
 
-MODALITIES_WITHOUT_DATA_ROOT = frozenset(
-    (ModalityType.TABULAR, ModalityType.TIMESERIES)
+TABULAR_LIKE_MODALITIES = frozenset((ModalityType.TABULAR, ModalityType.TIMESERIES))
+
+MODALITIES_WITH_OPTIONAL_TOP_LEVEL_DATA_ROOT = frozenset(
+    (*TABULAR_LIKE_MODALITIES, ModalityType.MULTIMODAL)
+)
+
+MULTIMODAL_CHILD_MODALITIES_WITH_DATA_ROOT = frozenset(
+    (MultimodalModalityType.VISION, MultimodalModalityType.RADAR)
 )
 
 
@@ -221,24 +237,48 @@ class QADataset(BaseModel):
             return None
         return value
 
-    def _validate_tabular_like_column_options(self) -> None:
-        has_extra_non_feature_cols = self.extra_non_feature_cols is not None
-        has_feature_cols = self.feature_cols is not None
-        if not has_extra_non_feature_cols and not has_feature_cols:
-            return
-        if has_extra_non_feature_cols and has_feature_cols:
-            raise ValueError(
-                "Only one of `extra_non_feature_cols` or `feature_cols` can be provided"
+    def _has_multimodal_labeling_info(self) -> bool:
+        if isinstance(self.labeling_info, MultimodalHirundoCSV):
+            return True
+        if isinstance(self.labeling_info, list):
+            return any(
+                isinstance(labeling_info, MultimodalHirundoCSV)
+                for labeling_info in self.labeling_info
             )
-        if self.modality not in MODALITIES_WITHOUT_DATA_ROOT:
+        return False
+
+    def _validate_multimodal_dataset(self) -> None:
+        if self.modality == ModalityType.MULTIMODAL:
+            if not isinstance(self.labeling_info, MultimodalHirundoCSV):
+                raise ValueError(
+                    "Multimodal datasets require `MultimodalHirundoCSV` labeling info"
+                )
+            if self.augmentations is not None:
+                raise ValueError(
+                    "Multimodal datasets do not support dataset-level augmentations"
+                )
+            missing_root_modalities = [
+                modality_csv.modality.value
+                for modality_csv in self.labeling_info.modality_csvs
+                if modality_csv.modality in MULTIMODAL_CHILD_MODALITIES_WITH_DATA_ROOT
+                and modality_csv.data_root_url is None
+                and self.data_root_url is None
+            ]
+            if missing_root_modalities:
+                raise ValueError(
+                    "Multimodal child modalities require a data root URL: "
+                    + ", ".join(missing_root_modalities)
+                )
+            return
+        if self._has_multimodal_labeling_info():
             raise ValueError(
-                "`extra_non_feature_cols` and `feature_cols` are only supported for tabular or timeseries datasets"
+                "MultimodalHirundoCSV labeling info is only supported for MULTIMODAL datasets"
             )
 
     def _validate_data_root_url(self) -> None:
         if (
             self.data_root_url is None
-            and self.modality not in MODALITIES_WITHOUT_DATA_ROOT
+            and self.modality not in MODALITIES_WITH_OPTIONAL_TOP_LEVEL_DATA_ROOT
         ):
             raise ValueError(
                 "`data_root_url` is required for non-tabular Dataset QA datasets"
@@ -281,7 +321,13 @@ class QADataset(BaseModel):
             raise ValueError(
                 f"Labeling type {self.labeling_type} is not supported for modality {self.modality}. Supported labeling types are: {MODALITY_TO_SUPPORTED_LABELING_TYPES[self.modality]}"
             )
-        self._validate_tabular_like_column_options()
+        validate_column_options(
+            feature_cols=self.feature_cols,
+            extra_non_feature_cols=self.extra_non_feature_cols,
+            modality=self.modality,
+            allowed_modalities=TABULAR_LIKE_MODALITIES,
+            unsupported_message="`extra_non_feature_cols` and `feature_cols` are only supported for tabular or timeseries datasets",
+        )
         self._ensure_storage_config_consistency(
             missing_message="No dataset storage has been provided. Provide one via `storage_config` or `storage_config_id`",
             mismatch_message="Both `storage_config` and `storage_config_id` have been provided. Pick one.",
@@ -316,6 +362,7 @@ class QADataset(BaseModel):
             validate_labeling_info(
                 self.labeling_type, self.labeling_info, self.storage_config
             )
+        self._validate_multimodal_dataset()
         self._validate_data_root_url()
         return self
 
@@ -474,7 +521,12 @@ class QADataset(BaseModel):
                 )
         model_dict = self.model_dump(mode="json", exclude={"storage_config"})
         # ⬆️ Get dict of model fields from Pydantic model instance
-        for optional_key in ("data_root_url", "extra_non_feature_cols", "feature_cols"):
+        for optional_key in (
+            "data_root_url",
+            "augmentations",
+            "extra_non_feature_cols",
+            "feature_cols",
+        ):
             if model_dict[optional_key] is None:
                 model_dict.pop(optional_key)
         dataset_response = requests.post(
@@ -828,6 +880,7 @@ class QADatasetOut(BaseModel):
 
     classes: list[str] | None = None
     labeling_info: LabelingInfo | list[LabelingInfo]
+    augmentations: list[AugmentationName] | None = None
 
     organization_id: int | None
     creator_id: int | None

--- a/hirundo/labeling.py
+++ b/hirundo/labeling.py
@@ -1,8 +1,10 @@
 import typing
 from abc import ABC
+from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
+from hirundo._column_options import validate_column_options
 from hirundo._urls import HirundoUrl
 from hirundo.dataset_enum import DatasetMetadataType
 
@@ -26,6 +28,125 @@ class HirundoCSV(Metadata, frozen=True):
     or `ssh://my-username@my-repo-name/my-folder/my-metadata.csv`
     (or `file:///datasets/my-folder/my-metadata.csv` if using LOCAL storage type with on-premises installation)
     """
+
+
+class MultimodalModalityType(str, Enum):
+    VISION = "VISION"
+    RADAR = "RADAR"
+    TABULAR = "TABULAR"
+    TIMESERIES = "TIMESERIES"
+
+
+IMAGE_MULTIMODAL_AUGMENTATIONS = frozenset(
+    (
+        "RandomHorizontalFlip",
+        "RandomVerticalFlip",
+        "RandomRotation",
+        "RandomPerspective",
+        "GaussianNoise",
+        "RandomGrayscale",
+        "GaussianBlur",
+    )
+)
+
+TABULAR_MULTIMODAL_AUGMENTATIONS = frozenset(("AddGaussianNoise", "MaskFeatures"))
+
+MULTIMODAL_AUGMENTATIONS_BY_MODALITY = {
+    MultimodalModalityType.VISION: IMAGE_MULTIMODAL_AUGMENTATIONS,
+    MultimodalModalityType.RADAR: IMAGE_MULTIMODAL_AUGMENTATIONS,
+    MultimodalModalityType.TABULAR: TABULAR_MULTIMODAL_AUGMENTATIONS,
+    MultimodalModalityType.TIMESERIES: TABULAR_MULTIMODAL_AUGMENTATIONS,
+}
+
+MULTIMODAL_AUGMENTATIONS = frozenset(
+    augmentation
+    for augmentations in MULTIMODAL_AUGMENTATIONS_BY_MODALITY.values()
+    for augmentation in augmentations
+)
+
+
+class MultimodalModalityCSV(BaseModel, frozen=True):
+    modality: MultimodalModalityType
+    labeling_info: HirundoCSV
+    data_root_url: HirundoUrl | None = None
+    augmentations: list[str] | None = None
+    feature_cols: list[str] | None = None
+    extra_non_feature_cols: list[str] | None = None
+
+    @field_validator("extra_non_feature_cols", "feature_cols", mode="before")
+    @classmethod
+    def _normalize_empty_column_options(cls, value):
+        if value == []:
+            return None
+        return value
+
+    @field_validator("augmentations", mode="before")
+    @classmethod
+    def _validate_known_augmentations(cls, value):
+        if value is None:
+            return None
+        invalid_augmentations = [
+            str(getattr(augmentation, "value", augmentation))
+            for augmentation in value
+            if str(getattr(augmentation, "value", augmentation))
+            not in MULTIMODAL_AUGMENTATIONS
+        ]
+        if invalid_augmentations:
+            raise ValueError(
+                "Invalid multimodal child augmentations: "
+                + ", ".join(invalid_augmentations)
+            )
+        return value
+
+    @field_validator("modality", mode="before")
+    @classmethod
+    def _legacy_image_modality(cls, modality: object) -> object:
+        if modality == "IMAGE":
+            return MultimodalModalityType.VISION
+        return modality
+
+    @model_validator(mode="after")
+    def _validate_child_options(self) -> "MultimodalModalityCSV":
+        validate_column_options(
+            feature_cols=self.feature_cols,
+            extra_non_feature_cols=self.extra_non_feature_cols,
+            modality=self.modality,
+            allowed_modalities=frozenset(
+                (MultimodalModalityType.TABULAR, MultimodalModalityType.TIMESERIES)
+            ),
+            unsupported_message=(
+                "Multimodal feature column settings are only supported for tabular or timeseries child modalities"
+            ),
+        )
+        if self.augmentations is not None:
+            allowed_augmentations = MULTIMODAL_AUGMENTATIONS_BY_MODALITY[self.modality]
+            invalid_augmentations = [
+                augmentation
+                for augmentation in self.augmentations
+                if augmentation not in allowed_augmentations
+            ]
+            if invalid_augmentations:
+                raise ValueError(
+                    f"Invalid augmentations [{', '.join(invalid_augmentations)}] for {self.modality.value} modality"
+                )
+        return self
+
+
+class MultimodalHirundoCSV(Metadata, frozen=True):
+    type: typing.Literal[DatasetMetadataType.MULTIMODAL_HIRUNDO_CSV] = (
+        DatasetMetadataType.MULTIMODAL_HIRUNDO_CSV
+    )
+    modality_csvs: list[MultimodalModalityCSV]
+    alignment_csv_url: HirundoUrl | None = None
+
+    @model_validator(mode="after")
+    def _validate_modality_csvs(self) -> "MultimodalHirundoCSV":
+        if len(self.modality_csvs) < 2:
+            raise ValueError("Multimodal datasets require at least two modalities")
+        modalities = [modality_csv.modality for modality_csv in self.modality_csvs]
+        if len(set(modalities)) != len(modalities):
+            raise ValueError("Multimodal dataset modalities must be unique")
+        return self
 
 
 class COCO(Metadata, frozen=True):
@@ -126,7 +247,7 @@ The dataset labeling info for Keylabs. The dataset labeling info can be one of t
 - `DatasetMetadataType.KeylabsObjSegVideo`: Indicates that the dataset metadata file is in the Keylabs object segmentation video format
 """
 LabelingInfo = typing.Annotated[
-    HirundoCSV | COCO | YOLO | KeylabsInfo | HuggingFaceAudio,
+    HirundoCSV | MultimodalHirundoCSV | COCO | YOLO | KeylabsInfo | HuggingFaceAudio,
     Field(discriminator="type"),
 ]
 """

--- a/tests/test_dataset_qa_config.py
+++ b/tests/test_dataset_qa_config.py
@@ -1,7 +1,15 @@
 from typing import Any
 
 import pytest
-from hirundo import HirundoCSV, LabelingType, ModalityType, QADataset
+from hirundo import (
+    HirundoCSV,
+    LabelingType,
+    ModalityType,
+    MultimodalHirundoCSV,
+    MultimodalModalityCSV,
+    MultimodalModalityType,
+    QADataset,
+)
 from pydantic_core import Url
 
 
@@ -78,6 +86,21 @@ def _capture_create_payload(
     return request_payloads
 
 
+def _capture_create_and_run_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any] | None]:
+    request_payloads: list[dict[str, Any] | None] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> _Response:
+        request_payloads.append(kwargs.get("json"))
+        if str(args[0]).endswith("/dataset-qa/run/123"):
+            return _Response({"run_id": "run-123"})
+        return _create_dataset_response()
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.post", fake_post)
+    return request_payloads
+
+
 def test_tabular_extra_non_feature_cols_are_serialized(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -128,16 +151,7 @@ def test_timeseries_column_options_are_serialized(
 def test_timeseries_dataset_run_launches_after_create(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    request_payloads: list[dict[str, Any] | None] = []
-
-    def fake_post(*args: Any, **kwargs: Any) -> _Response:
-        request_payloads.append(kwargs.get("json"))
-        if str(args[0]).endswith("/dataset-qa/run/123"):
-            return _Response({"run_id": "run-123"})
-        return _create_dataset_response()
-
-    monkeypatch.setattr("hirundo.dataset_qa.requests.post", fake_post)
-
+    request_payloads = _capture_create_and_run_payloads(monkeypatch)
     dataset = _build_dataset(modality=ModalityType.TIMESERIES)
 
     assert dataset.run_qa() == "run-123"
@@ -145,6 +159,70 @@ def test_timeseries_dataset_run_launches_after_create(
     create_payload = request_payloads[0]
     assert create_payload is not None
     assert create_payload["modality"] == ModalityType.TIMESERIES
+
+
+def _build_multimodal_labeling_info() -> MultimodalHirundoCSV:
+    return MultimodalHirundoCSV(
+        modality_csvs=[
+            MultimodalModalityCSV(
+                modality=MultimodalModalityType.VISION,
+                labeling_info=HirundoCSV(csv_url=Url("gs://bucket/image.csv")),
+                data_root_url=Url("gs://bucket/images"),
+                augmentations=["RandomHorizontalFlip"],
+            ),
+            MultimodalModalityCSV(
+                modality=MultimodalModalityType.TABULAR,
+                labeling_info=HirundoCSV(csv_url=Url("gs://bucket/tabular.csv")),
+                extra_non_feature_cols=["sample_id"],
+            ),
+        ],
+        alignment_csv_url=Url("gs://bucket/alignment.csv"),
+    )
+
+
+def _build_multimodal_labeling_info_payload() -> dict[str, Any]:
+    return _build_multimodal_labeling_info().model_dump(mode="json")
+
+
+def _build_multimodal_dataset(**overrides: Any) -> QADataset:
+    dataset_payload = {
+        "name": "multimodal dataset",
+        "modality": ModalityType.MULTIMODAL,
+        "data_root_url": None,
+        "labeling_info": _build_multimodal_labeling_info(),
+    }
+    dataset_payload.update(overrides)
+    return _build_dataset(**dataset_payload)
+
+
+def test_multimodal_dataset_creation_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_payloads = _capture_create_payload(monkeypatch)
+
+    dataset = _build_multimodal_dataset()
+    dataset.create()
+
+    create_payload = request_payloads[0]
+    assert create_payload["modality"] == ModalityType.MULTIMODAL
+    assert "data_root_url" not in create_payload
+    assert "augmentations" not in create_payload
+    assert create_payload["labeling_info"] == _build_multimodal_labeling_info_payload()
+
+
+def test_multimodal_dataset_run_launches_after_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_payloads = _capture_create_and_run_payloads(monkeypatch)
+    dataset = _build_multimodal_dataset()
+
+    assert dataset.run_qa() == "run-123"
+    assert dataset.run_id == "run-123"
+    create_payload = request_payloads[0]
+    run_payload = request_payloads[1]
+    assert create_payload is not None
+    assert create_payload["modality"] == ModalityType.MULTIMODAL
+    assert run_payload is None
 
 
 @pytest.mark.parametrize("modality", (ModalityType.TABULAR, ModalityType.TIMESERIES))
@@ -164,6 +242,116 @@ def test_tabular_like_datasets_can_omit_data_root_url(
 def test_data_root_url_is_required_for_non_tabular_like_datasets() -> None:
     with pytest.raises(ValueError, match="data_root_url"):
         _build_dataset(data_root_url=None, modality=ModalityType.VISION)
+
+
+def test_multimodal_file_child_requires_data_root_url() -> None:
+    labeling_info = MultimodalHirundoCSV(
+        modality_csvs=[
+            MultimodalModalityCSV(
+                modality=MultimodalModalityType.VISION,
+                labeling_info=HirundoCSV(csv_url=Url("gs://bucket/image.csv")),
+            ),
+            MultimodalModalityCSV(
+                modality=MultimodalModalityType.TABULAR,
+                labeling_info=HirundoCSV(csv_url=Url("gs://bucket/tabular.csv")),
+            ),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="VISION"):
+        _build_dataset(
+            modality=ModalityType.MULTIMODAL,
+            data_root_url=None,
+            labeling_info=labeling_info,
+        )
+
+
+def test_multimodal_rejects_dataset_level_augmentations() -> None:
+    with pytest.raises(ValueError, match="dataset-level augmentations"):
+        _build_multimodal_dataset(
+            augmentations=["RandomHorizontalFlip"],
+        )
+
+
+def test_multimodal_rejects_top_level_column_options() -> None:
+    with pytest.raises(ValueError, match="tabular or timeseries datasets"):
+        _build_multimodal_dataset(feature_cols=["age"])
+
+
+def test_multimodal_child_empty_column_options_are_normalized() -> None:
+    modality_csv = MultimodalModalityCSV(
+        modality=MultimodalModalityType.TABULAR,
+        labeling_info=HirundoCSV(csv_url=Url("gs://bucket/tabular.csv")),
+        feature_cols=[],
+        extra_non_feature_cols=[],
+    )
+
+    assert modality_csv.feature_cols is None
+    assert modality_csv.extra_non_feature_cols is None
+
+
+def test_multimodal_child_rejects_unknown_augmentation() -> None:
+    with pytest.raises(ValueError, match="TypoAugmentation"):
+        MultimodalModalityCSV(
+            modality=MultimodalModalityType.VISION,
+            labeling_info=HirundoCSV(csv_url=Url("gs://bucket/image.csv")),
+            data_root_url=Url("gs://bucket/images"),
+            augmentations=["TypoAugmentation"],
+        )
+
+
+def test_multimodal_child_rejects_augmentation_for_wrong_modality() -> None:
+    with pytest.raises(ValueError, match="TABULAR"):
+        MultimodalModalityCSV(
+            modality=MultimodalModalityType.TABULAR,
+            labeling_info=HirundoCSV(csv_url=Url("gs://bucket/tabular.csv")),
+            augmentations=["RandomHorizontalFlip"],
+        )
+
+
+def test_multimodal_child_accepts_legacy_image_modality() -> None:
+    modality_csv = MultimodalModalityCSV.model_validate(
+        {
+            "modality": "IMAGE",
+            "labeling_info": {
+                "type": "HirundoCSV",
+                "csv_url": "gs://bucket/image.csv",
+            },
+        }
+    )
+
+    assert modality_csv.modality == MultimodalModalityType.VISION
+
+
+def test_multimodal_labeling_info_requires_at_least_two_modalities() -> None:
+    with pytest.raises(ValueError, match="at least two modalities"):
+        MultimodalHirundoCSV(
+            modality_csvs=[
+                MultimodalModalityCSV(
+                    modality=MultimodalModalityType.VISION,
+                    labeling_info=HirundoCSV(csv_url=Url("gs://bucket/image.csv")),
+                    data_root_url=Url("gs://bucket/images"),
+                )
+            ]
+        )
+
+
+def test_multimodal_labeling_info_rejects_duplicate_modalities() -> None:
+    with pytest.raises(ValueError, match="modalities must be unique"):
+        MultimodalHirundoCSV(
+            modality_csvs=[
+                MultimodalModalityCSV(
+                    modality=MultimodalModalityType.VISION,
+                    labeling_info=HirundoCSV(csv_url=Url("gs://bucket/image.csv")),
+                    data_root_url=Url("gs://bucket/images"),
+                ),
+                MultimodalModalityCSV(
+                    modality=MultimodalModalityType.VISION,
+                    labeling_info=HirundoCSV(csv_url=Url("gs://bucket/image-2.csv")),
+                    data_root_url=Url("gs://bucket/images-2"),
+                ),
+            ]
+        )
 
 
 def test_tabular_column_options_default_to_none() -> None:
@@ -279,6 +467,70 @@ def test_get_by_id_accepts_timeseries_modality(
     assert dataset.extra_non_feature_cols == ["sequence_id"]
 
 
+def test_get_by_id_accepts_multimodal_modality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            _build_dataset_payload(
+                id=123,
+                name="multimodal dataset",
+                modality="MULTIMODAL",
+                data_root_url=None,
+                labeling_info=_build_multimodal_labeling_info_payload(),
+            )
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    dataset = QADataset.get_by_id(123)
+
+    assert dataset.modality == ModalityType.MULTIMODAL
+    assert isinstance(dataset.labeling_info, MultimodalHirundoCSV)
+    assert dataset.labeling_info.modality_csvs[0].modality == (
+        MultimodalModalityType.VISION
+    )
+    assert dataset.labeling_info.modality_csvs[1].extra_non_feature_cols == [
+        "sample_id"
+    ]
+
+
+def test_get_by_id_accepts_multimodal_child_empty_column_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    labeling_info = _build_multimodal_labeling_info_payload()
+    labeling_info["modality_csvs"][1]["feature_cols"] = []
+    labeling_info["modality_csvs"][1]["extra_non_feature_cols"] = []
+
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            _build_dataset_payload(
+                id=123,
+                name="multimodal dataset",
+                modality="MULTIMODAL",
+                data_root_url=None,
+                labeling_info=labeling_info,
+            )
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    dataset = QADataset.get_by_id(123)
+
+    assert isinstance(dataset.labeling_info, MultimodalHirundoCSV)
+    tabular_child = dataset.labeling_info.modality_csvs[1]
+    assert tabular_child.feature_cols is None
+    assert tabular_child.extra_non_feature_cols is None
+
+
+def test_multimodal_labeling_info_list_is_rejected_for_non_multimodal_dataset() -> None:
+    with pytest.raises(ValueError, match="MULTIMODAL datasets"):
+        _build_dataset(
+            modality=ModalityType.VISION,
+            labeling_info=[_build_multimodal_labeling_info()],
+        )
+
+
 def test_list_datasets_accepts_timeseries_modality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -309,6 +561,38 @@ def test_list_datasets_accepts_timeseries_modality(
     assert dataset.data_root_url is None
 
 
+def test_list_datasets_accepts_multimodal_modality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            [
+                _build_dataset_payload(
+                    id=123,
+                    name="multimodal dataset",
+                    modality=ModalityType.MULTIMODAL,
+                    data_root_url=None,
+                    labeling_info=_build_multimodal_labeling_info_payload(),
+                    storage_config=_build_storage_config_payload(
+                        name="multimodal-storage"
+                    ),
+                    organization_id=789,
+                    creator_id=321,
+                    created_at="2026-06-22T14:20:31.663Z",
+                    updated_at="2026-06-22T14:20:31.663Z",
+                )
+            ]
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    dataset = QADataset.list_datasets()[0]
+
+    assert dataset.modality == ModalityType.MULTIMODAL
+    assert isinstance(dataset.labeling_info, MultimodalHirundoCSV)
+    assert dataset.data_root_url is None
+
+
 def test_list_runs_accepts_timeseries_modality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -334,3 +618,30 @@ def test_list_runs_accepts_timeseries_modality(
     run = QADataset.list_runs()[0]
 
     assert run.modality == ModalityType.TIMESERIES
+
+
+def test_list_runs_accepts_multimodal_modality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(*args: Any, **kwargs: Any) -> _Response:
+        return _Response(
+            [
+                {
+                    "id": 1,
+                    "name": "multimodal run",
+                    "dataset_id": 123,
+                    "run_id": "run-123",
+                    "modality": "MULTIMODAL",
+                    "status": "PENDING",
+                    "approved": False,
+                    "created_at": "2026-06-22T14:20:31.663Z",
+                    "run_args": None,
+                }
+            ]
+        )
+
+    monkeypatch.setattr("hirundo.dataset_qa.requests.get", fake_get)
+
+    run = QADataset.list_runs()[0]
+
+    assert run.modality == ModalityType.MULTIMODAL


### PR DESCRIPTION
# User description
## Summary
- add SDK models for multimodal Dataset QA metadata and child modality CSVs
- support multimodal dataset creation, validation, response hydration, and run launch through the existing Dataset QA endpoints
- add focused tests for create payloads, hydration, list parsing, and validation behavior

## Validation
- pytest tests/test_dataset_qa_config.py
- ruff check .
- ruff format --check .
- basedpyright

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend <code>QADataset</code> validation, serialization, and modality enums to honor the new <code>MultimodalHirundoCSV</code> contract so multimodal Dataset QA datasets can be created, hydrated, and run through the existing endpoints. Document the multimodal flow with a storage-backed example and ensure the SDK surface exposes the new metadata types and augmentations referenced by the ticket’s goal of enabling multimodal QA flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/262?tool=ast&topic=Docs+%26+Tests>Docs & Tests</a>
        </td><td>Demonstrate and verify the multimodal experience by adding a docs example that wires storage-backed CSVs and by expanding Dataset QA config tests to cover multimodal payloads, validation rules, hydration, and run/list parsing.<details><summary>Modified files (3)</summary><ul><li>docs/dataset_qa_multimodal_example.py</li>
<li>docs/index.rst</li>
<li>tests/test_dataset_qa_config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Add multimodal Dataset...</td><td>June 24, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add LLM behavior eval ...</td><td>February 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/262?tool=ast&topic=Multimodal+QA+Flow>Multimodal QA Flow</a>
        </td><td>Enable multimodal Dataset QA flow by wiring <code>QADataset</code>, <code>LabelingInfo</code>, and <code>Storage</code> validation helpers to the new <code>MultimodalHirundoCSV</code>/<code>MultimodalModalityCSV</code> models, updating enums, and exposing the metadata types so the created datasets and runs cover the platform contract.<details><summary>Modified files (6)</summary><ul><li>hirundo/__init__.py</li>
<li>hirundo/_column_options.py</li>
<li>hirundo/_constraints.py</li>
<li>hirundo/dataset_enum.py</li>
<li>hirundo/dataset_qa.py</li>
<li>hirundo/labeling.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Add multimodal Dataset...</td><td>June 24, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>v0.2.4 (#254)</td><td>June 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/262?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>