### PR TITLE
SDK-113: Skip broken historical docs tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,11 @@ autodoc_pydantic_field_show_constraints = False
 autodoc_pydantic_field_list_validators = False
 autodoc_pydantic_model_hide_reused_validator = True
 
-smv_tag_whitelist = r"^v.*$"
+# These historical releases fail under the current docs dependency set because
+# autodoc-pydantic now errors on unresolved Pydantic forward references.
+smv_tag_whitelist = (
+    r"^v(?!(?:0\.1\.17\+on-prem|0\.1\.18|0\.1\.19(?:\.\d+)?\+on-prem|0\.1\.21)$).*$"
+)
 smv_branch_whitelist = "None"
 
 templates_path = ["_templates"]


### PR DESCRIPTION
# User description
## Summary
- Exclude historical Sphinx multiversion tags that fail under the current docs dependency environment.
- Keep current and adjacent release tags included in the multiversion docs build.

## Root cause
`sphinx-multiversion` rebuilds old release tags using the current docs dependencies. Some historical tags have unresolved Pydantic forward references that now raise during autodoc-pydantic schema generation.

## Validation
- `uv run ruff check docs/conf.py`
- `uv run ruff format --check docs/conf.py`
- `API_HOST=something API_KEY=something sphinx-build -b html docs /tmp/hirundo-docs-single`
- `API_HOST=something API_KEY=something sphinx-multiversion docs /tmp/hirundo-docs-multi-current`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjusts the Sphinx multiversion tag whitelist so autodoc-pydantic no longer encounters unresolved <code>HirundoUrl</code> forward refs while generating JSON schemas for old releases. Verifies that the remaining tag selection still lets the current docs dependency set build the supported historical versions successfully.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Skip broken historical...</td><td>June 24, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>v0.2.4 (#254)</td><td>June 09, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/263?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>