### PR TITLE
SDK-118: Align multimodal data root validation

### DIFF
--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -29,10 +29,10 @@ from hirundo._urls import HirundoUrl
 from hirundo.dataset_enum import DatasetMetadataType, LabelingType
 from hirundo.dataset_qa_results import DatasetQAResults
 from hirundo.labeling import (
+    MULTIMODAL_MODALITIES_WITH_DATA_ROOT,
     YOLO,
     LabelingInfo,
     MultimodalHirundoCSV,
-    MultimodalModalityType,
 )
 from hirundo.logger import get_logger
 from hirundo.storage import ResponseStorageConfig, StorageConfig
@@ -140,13 +140,7 @@ MODALITY_TO_SUPPORTED_LABELING_TYPES = {
 
 TABULAR_LIKE_MODALITIES = frozenset((ModalityType.TABULAR, ModalityType.TIMESERIES))
 
-MODALITIES_WITH_OPTIONAL_TOP_LEVEL_DATA_ROOT = frozenset(
-    (*TABULAR_LIKE_MODALITIES, ModalityType.MULTIMODAL)
-)
-
-MULTIMODAL_CHILD_MODALITIES_WITH_DATA_ROOT = frozenset(
-    (MultimodalModalityType.VISION, MultimodalModalityType.RADAR)
-)
+MODALITIES_WITH_OPTIONAL_TOP_LEVEL_DATA_ROOT = TABULAR_LIKE_MODALITIES
 
 
 class QADataset(BaseModel):
@@ -257,12 +251,16 @@ class QADataset(BaseModel):
                 raise ValueError(
                     "Multimodal datasets do not support dataset-level augmentations"
                 )
+            if self.data_root_url is not None:
+                raise ValueError(
+                    "Multimodal datasets do not support top-level `data_root_url`; "
+                    "set it on vision or radar child modalities instead"
+                )
             missing_root_modalities = [
                 modality_csv.modality.value
                 for modality_csv in self.labeling_info.modality_csvs
-                if modality_csv.modality in MULTIMODAL_CHILD_MODALITIES_WITH_DATA_ROOT
+                if modality_csv.modality in MULTIMODAL_MODALITIES_WITH_DATA_ROOT
                 and modality_csv.data_root_url is None
-                and self.data_root_url is None
             ]
             if missing_root_modalities:
                 raise ValueError(
@@ -278,6 +276,7 @@ class QADataset(BaseModel):
     def _validate_data_root_url(self) -> None:
         if (
             self.data_root_url is None
+            and self.modality != ModalityType.MULTIMODAL
             and self.modality not in MODALITIES_WITH_OPTIONAL_TOP_LEVEL_DATA_ROOT
         ):
             raise ValueError(

--- a/hirundo/labeling.py
+++ b/hirundo/labeling.py
@@ -64,6 +64,14 @@ MULTIMODAL_AUGMENTATIONS = frozenset(
     for augmentation in augmentations
 )
 
+MULTIMODAL_MODALITIES_WITH_DATA_ROOT = frozenset(
+    (MultimodalModalityType.VISION, MultimodalModalityType.RADAR)
+)
+
+MULTIMODAL_MODALITIES_WITHOUT_DATA_ROOT = frozenset(
+    (MultimodalModalityType.TABULAR, MultimodalModalityType.TIMESERIES)
+)
+
 
 class MultimodalModalityCSV(BaseModel, frozen=True):
     modality: MultimodalModalityType
@@ -129,6 +137,13 @@ class MultimodalModalityCSV(BaseModel, frozen=True):
                 raise ValueError(
                     f"Invalid augmentations [{', '.join(invalid_augmentations)}] for {self.modality.value} modality"
                 )
+        if (
+            self.modality in MULTIMODAL_MODALITIES_WITHOUT_DATA_ROOT
+            and self.data_root_url is not None
+        ):
+            raise ValueError(
+                "`data_root_url` is only supported for vision or radar child modalities"
+            )
         return self
 
 

--- a/tests/test_dataset_qa_config.py
+++ b/tests/test_dataset_qa_config.py
@@ -266,6 +266,26 @@ def test_multimodal_file_child_requires_data_root_url() -> None:
         )
 
 
+def test_multimodal_rejects_top_level_data_root_url() -> None:
+    with pytest.raises(ValueError, match="top-level `data_root_url`"):
+        _build_multimodal_dataset(data_root_url=Url("gs://bucket/images"))
+
+
+@pytest.mark.parametrize(
+    "modality",
+    (MultimodalModalityType.TABULAR, MultimodalModalityType.TIMESERIES),
+)
+def test_multimodal_tabular_like_child_rejects_data_root_url(
+    modality: MultimodalModalityType,
+) -> None:
+    with pytest.raises(ValueError, match="vision or radar child modalities"):
+        MultimodalModalityCSV(
+            modality=modality,
+            labeling_info=HirundoCSV(csv_url=Url("gs://bucket/metadata.csv")),
+            data_root_url=Url("gs://bucket/data"),
+        )
+
+
 def test_multimodal_rejects_dataset_level_augmentations() -> None:
     with pytest.raises(ValueError, match="dataset-level augmentations"):
         _build_multimodal_dataset(


### PR DESCRIPTION
# User description
## Summary
- reject top-level data_root_url for multimodal Dataset QA inputs
- keep data_root_url limited to vision/radar multimodal child modalities
- add regression coverage for multimodal parent and tabular/timeseries child validation

## Verification
- source .venv/bin/activate && pytest tests/test_dataset_qa_config.py
- source .venv/bin/activate && ruff check .
- source .venv/bin/activate && ruff format .
- source .venv/bin/activate && basedpyright

Full default pytest collection is blocked locally by missing integration credentials: AWS_ACCESS_KEY, GCP_CREDENTIALS, and HUGGINGFACE_ACCESS_TOKEN.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align QADataset and MultimodalModalityCSV validation with UI multimodal flows by rejecting top-level <code>data_root_url</code> and limiting it to radar/vision children while keeping tabular/timeseries roots disallowed. Ensure the SDK mirrors UI expectations so that multimodal datasets surface the same child-specific file-backed roots instead of a parent-level fallback.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/267?tool=ast&topic=Regression+tests>Regression tests</a>
        </td><td>Add regression tests that cover the new multimodal validation expectations for parent-level and tabular/timeseries child <code>data_root_url</code> usage.<details><summary>Modified files (1)</summary><ul><li>tests/test_dataset_qa_config.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Merge remote-tracking ...</td><td>July 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/267?tool=ast&topic=Multimodal+root+rules>Multimodal root rules</a>
        </td><td>Enforce multimodal root rules by preventing dataset-level <code>data_root_url</code>, requiring child-level roots for radar/vision, and rejecting them for tabular/timeseries modalities.<details><summary>Modified files (2)</summary><ul><li>hirundo/dataset_qa.py</li>
<li>hirundo/labeling.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Merge remote-tracking ...</td><td>July 02, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add LLM behavior eval ...</td><td>February 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/267?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>