### PR TITLE
SDK-117: Fix Dataset QA run organization handling

### DIFF
--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -562,14 +562,14 @@ class QADataset(BaseModel):
         Returns:
             ID of the run (`run_id`).
         """
-        run_info = {}
-        if organization_id:
+        run_info: dict[str, typing.Any] = {
+            "run_args": run_args.model_dump(mode="json") if run_args else {},
+        }
+        if organization_id is not None:
             run_info["organization_id"] = organization_id
-        if run_args:
-            run_info["run_args"] = run_args.model_dump(mode="json")
         run_response = requests.post(
             f"{API_HOST}/dataset-qa/run/{dataset_id}",
-            json=run_info if len(run_info) > 0 else None,
+            json=run_info,
             headers=get_headers(),
             timeout=MODIFY_TIMEOUT,
         )
@@ -618,7 +618,10 @@ class QADataset(BaseModel):
         """
         try:
             if not self.id:
-                self.id = self.create(replace_if_exists=replace_dataset_if_exists)
+                self.id = self.create(
+                    organization_id=organization_id,
+                    replace_if_exists=replace_dataset_if_exists,
+                )
             if run_args is not None:
                 self._validate_run_args(run_args)
             run_id = self.launch_qa_run(self.id, organization_id, run_args)

--- a/hirundo/dataset_qa.py
+++ b/hirundo/dataset_qa.py
@@ -517,6 +517,7 @@ class QADataset(BaseModel):
                 self.storage_config_id = self.storage_config.id
             elif isinstance(self.storage_config, StorageConfig):
                 self.storage_config_id = self.storage_config.create(
+                    organization_id=organization_id,
                     replace_if_exists=replace_if_exists,
                 )
         model_dict = self.model_dump(mode="json", exclude={"storage_config"})

--- a/hirundo/git.py
+++ b/hirundo/git.py
@@ -118,7 +118,7 @@ class GitRepo(BaseModel):
         Create a Git repository in the Hirundo system.
 
         Args:
-            organization_id: The ID of the organization to create the Git repository for.
+            organization_id (optional): The ID of the organization to create the Git repository for.
             replace_if_exists: If a Git repository with the same name already exists, replace it.
         """
         git_repo_info = self.model_dump(mode="json")

--- a/hirundo/git.py
+++ b/hirundo/git.py
@@ -109,17 +109,25 @@ class GitRepo(BaseModel):
             repository_url = Url(repository_url)
         return repository_url
 
-    def create(self, replace_if_exists: bool = False) -> int:
+    def create(
+        self,
+        organization_id: int | None = None,
+        replace_if_exists: bool = False,
+    ) -> int:
         """
         Create a Git repository in the Hirundo system.
 
         Args:
+            organization_id: The ID of the organization to create the Git repository for.
             replace_if_exists: If a Git repository with the same name already exists, replace it.
         """
+        git_repo_info = self.model_dump(mode="json")
+        if organization_id is not None:
+            git_repo_info["organization_id"] = organization_id
         git_repo = requests.post(
             f"{API_HOST}/git-repo/",
             json={
-                **self.model_dump(mode="json"),
+                **git_repo_info,
                 "replace_if_exists": replace_if_exists,
             },
             headers=get_headers(),

--- a/hirundo/storage.py
+++ b/hirundo/storage.py
@@ -392,6 +392,9 @@ class StorageConfig(BaseModel):
         Args:
             organization_id (optional): The ID of the organization to create the storage config for.
             replace_if_exists: If a :code:`StorageConfig` with the same name and type already exists, replace it.
+
+        Returns:
+            The ID of the created storage config.
         """
         if self.git and self.git.repo:
             self.git.repo_id = self.git.repo.create(

--- a/hirundo/storage.py
+++ b/hirundo/storage.py
@@ -381,19 +381,30 @@ class StorageConfig(BaseModel):
             raise ValueError("No StorageConfig has been created")
         self.delete_by_id(self.id)
 
-    def create(self, replace_if_exists: bool = False) -> int:
+    def create(
+        self,
+        organization_id: int | None = None,
+        replace_if_exists: bool = False,
+    ) -> int:
         """
         Create a :code:`StorageConfig` instance on the server
 
         Args:
+            organization_id: The ID of the organization to create the storage config for.
             replace_if_exists: If a :code:`StorageConfig` with the same name and type already exists, replace it.
         """
         if self.git and self.git.repo:
-            self.git.repo_id = self.git.repo.create(replace_if_exists=replace_if_exists)
+            self.git.repo_id = self.git.repo.create(
+                organization_id=organization_id,
+                replace_if_exists=replace_if_exists,
+            )
+        storage_config_info = self.model_dump(mode="json")
+        if organization_id is not None:
+            storage_config_info["organization_id"] = organization_id
         storage_config = requests.post(
             f"{API_HOST}/storage-config/",
             json={
-                **self.model_dump(mode="json"),
+                **storage_config_info,
                 "replace_if_exists": replace_if_exists,
             },
             headers=get_headers(),

--- a/hirundo/storage.py
+++ b/hirundo/storage.py
@@ -390,7 +390,7 @@ class StorageConfig(BaseModel):
         Create a :code:`StorageConfig` instance on the server
 
         Args:
-            organization_id: The ID of the organization to create the storage config for.
+            organization_id (optional): The ID of the organization to create the storage config for.
             replace_if_exists: If a :code:`StorageConfig` with the same name and type already exists, replace it.
         """
         if self.git and self.git.repo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ Homepage = "https://github.com/Hirundo-io/hirundo-python-sdk"
 pandas = ["pandas>=2.2.3"]
 polars = ["polars>=1.0.0"]
 transformers = [
-    "transformers>=5.0.0",
-    #  ⬆️ Required to fix vulnerability CVE-2026-1839
+    "transformers>=5.3.0",
+    #  ⬆️ Required to fix vulnerabilities CVE-2026-1839 and CVE-2026-4372
     "torch>=2.12.1",
     #  ⬆️ Required to fix vulnerabilities CVE-2025-3000
     "peft>=0.18.1",

--- a/tests/test_dataset_qa_config.py
+++ b/tests/test_dataset_qa_config.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 from hirundo import (
+    GitRepo,
     HirundoCSV,
     LabelingType,
     ModalityType,
@@ -9,6 +10,10 @@ from hirundo import (
     MultimodalModalityCSV,
     MultimodalModalityType,
     QADataset,
+    StorageConfig,
+    StorageGCP,
+    StorageGit,
+    StorageTypes,
 )
 from pydantic_core import Url
 
@@ -101,6 +106,38 @@ def _capture_create_and_run_payloads(
     return request_payloads
 
 
+def _capture_storage_and_dataset_create_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    request_payloads: list[dict[str, Any]] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> _Response:
+        request_payloads.append(kwargs["json"])
+        if str(args[0]).endswith("/storage-config/"):
+            return _Response({"id": 456})
+        return _create_dataset_response()
+
+    monkeypatch.setattr("hirundo.storage.requests.post", fake_post)
+    monkeypatch.setattr("hirundo.dataset_qa.requests.post", fake_post)
+    return request_payloads
+
+
+def _capture_git_and_storage_create_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    request_payloads: list[dict[str, Any]] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> _Response:
+        request_payloads.append(kwargs["json"])
+        if str(args[0]).endswith("/git-repo/"):
+            return _Response({"id": 321})
+        return _Response({"id": 456})
+
+    monkeypatch.setattr("hirundo.git.requests.post", fake_post)
+    monkeypatch.setattr("hirundo.storage.requests.post", fake_post)
+    return request_payloads
+
+
 def test_tabular_extra_non_feature_cols_are_serialized(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -121,6 +158,53 @@ def test_tabular_feature_cols_are_serialized(
     dataset.create()
 
     assert request_payloads[0]["feature_cols"] == ["age", "score"]
+
+
+def test_dataset_create_propagates_organization_to_storage_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_payloads = _capture_storage_and_dataset_create_payloads(monkeypatch)
+    dataset = _build_dataset(
+        storage_config_id=None,
+        storage_config=StorageConfig(
+            name="dataset-storage",
+            type=StorageTypes.GCP,
+            gcp=StorageGCP(bucket_name="bucket", project="project"),
+        ),
+    )
+
+    dataset.create(organization_id=4)
+
+    storage_payload = request_payloads[0]
+    dataset_payload = request_payloads[1]
+    assert storage_payload["organization_id"] == 4
+    assert dataset_payload["organization_id"] == 4
+    assert dataset_payload["storage_config_id"] == 456
+
+
+def test_storage_config_create_propagates_organization_to_git_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_payloads = _capture_git_and_storage_create_payloads(monkeypatch)
+    storage_config = StorageConfig(
+        name="dataset-git-storage",
+        type=StorageTypes.GIT,
+        git=StorageGit(
+            branch="main",
+            repo=GitRepo(
+                name="dataset-repo",
+                repository_url="https://example.com/org/repo.git",
+            ),
+        ),
+    )
+
+    assert storage_config.create(organization_id=4) == 456
+
+    git_payload = request_payloads[0]
+    storage_payload = request_payloads[1]
+    assert git_payload["organization_id"] == 4
+    assert storage_payload["organization_id"] == 4
+    assert storage_payload["git"]["repo_id"] == 321
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dataset_qa_config.py
+++ b/tests/test_dataset_qa_config.py
@@ -216,13 +216,24 @@ def test_multimodal_dataset_run_launches_after_create(
     request_payloads = _capture_create_and_run_payloads(monkeypatch)
     dataset = _build_multimodal_dataset()
 
-    assert dataset.run_qa() == "run-123"
+    assert dataset.run_qa(organization_id=4) == "run-123"
     assert dataset.run_id == "run-123"
     create_payload = request_payloads[0]
     run_payload = request_payloads[1]
     assert create_payload is not None
+    assert create_payload["organization_id"] == 4
     assert create_payload["modality"] == ModalityType.MULTIMODAL
-    assert run_payload is None
+    assert run_payload == {"organization_id": 4, "run_args": {}}
+
+
+def test_launch_qa_run_includes_default_run_args_with_organization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_payloads = _capture_create_and_run_payloads(monkeypatch)
+
+    assert QADataset.launch_qa_run(123, organization_id=4) == "run-123"
+
+    assert request_payloads == [{"organization_id": 4, "run_args": {}}]
 
 
 @pytest.mark.parametrize("modality", (ModalityType.TABULAR, ModalityType.TIMESERIES))

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ requires-dist = [
     { name = "stamina", specifier = ">=24.2.0" },
     { name = "torch", marker = "extra == 'transformers'", specifier = ">=2.12.1" },
     { name = "tqdm", specifier = ">=4.66.5" },
-    { name = "transformers", marker = "extra == 'transformers'", specifier = ">=5.0.0" },
+    { name = "transformers", marker = "extra == 'transformers'", specifier = ">=5.3.0" },
     { name = "typer", specifier = ">=0.12.3" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
     { name = "types-requests", specifier = ">=2.31.0" },


### PR DESCRIPTION
# User description
## Summary
- Pass `organization_id` through `QADataset.run_qa()` when it auto-creates a dataset.
- Propagate that organization through nested `StorageConfig.create()` and `GitRepo.create()` calls so implicitly created resources stay in the same org.
- Always include a default `run_args` object when launching Dataset QA runs so organization-only launch requests satisfy the on-prem server contract.
- Add coverage for the on-prem multimodal repro path, default `run_args`, and nested organization propagation.

`organization_id` matters here because `run_qa()` may implicitly call `create()` when the local `QADataset` has no server-side `id`; this PR ensures that implicit create path uses the requested organization consistently.

## Validation
- `source .venv/bin/activate && pytest tests/test_dataset_qa_config.py`
- `source .venv/bin/activate && pytest tests/test_dataset_qa_config.py tests/test_iter_sse_retrying.py`
- `source .venv/bin/activate && ruff check .`
- `source .venv/bin/activate && ruff format --check .`
- `source .venv/bin/activate && basedpyright`
- `source .venv/bin/activate && python -m build`

Full `pytest` collection requires credential env vars that are not present locally: `AWS_ACCESS_KEY`, `GCP_CREDENTIALS`, and `HUGGINGFACE_ACCESS_TOKEN`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure the on-prem Dataset QA flow consistently keeps <code>organization_id</code> attached by threading it through implicit dataset creation and by always supplying the default <code>run_args</code> payload before calling the launch endpoint. Tighten resource provisioning helpers and dependency versions so Git, storage, and QA launch code align with the updated run contract and security expectations.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/268?tool=ast&topic=Resource+Org+Propagation>Resource Org Propagation</a>
        </td><td>Propagate <code>organization_id</code> through dataset, storage, and Git creation layers so implicitly created storage configs and repos remain within the desired tenant when <code>run_qa()</code> auto-creates datasets.<details><summary>Modified files (4)</summary><ul><li>hirundo/dataset_qa.py</li>
<li>hirundo/git.py</li>
<li>hirundo/storage.py</li>
<li>tests/test_dataset_qa_config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Document storage confi...</td><td>July 01, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add LLM behavior eval ...</td><td>February 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/268?tool=ast&topic=QA+Run+Launch>QA Run Launch</a>
        </td><td>Ensure QA runs always include default run arguments and the requested <code>organization_id</code> so on-prem validation accepts organization-only launches and implicit dataset creation paths.<details><summary>Modified files (2)</summary><ul><li>hirundo/dataset_qa.py</li>
<li>tests/test_dataset_qa_config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Propagate organization...</td><td>July 01, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add LLM behavior eval ...</td><td>February 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/268?tool=ast&topic=Dependency+Security>Dependency Security</a>
        </td><td>Bump <code>transformers</code> to <code>>=5.3.0</code> across lockfiles to stay aligned with the updated QA flow and to cover CVE-2026-4372 in addition to CVE-2026-1839.<details><summary>Modified files (2)</summary><ul><li>pyproject.toml</li>
<li>uv.lock</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Raise transformers sec...</td><td>July 02, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>v0.2.4 (#254)</td><td>June 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/268?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>