### PR TITLE
SDK-121: Add manual release recovery workflow

### DIFF
--- a/.github/workflows/deploy-to-pypi.yaml
+++ b/.github/workflows/deploy-to-pypi.yaml
@@ -1,6 +1,20 @@
 name: Push new release of the package to PyPI
 
 on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Package index to publish to"
+        required: true
+        type: choice
+        options:
+          - pypi
+          - testpypi
+        default: pypi
+      version:
+        description: "Expected version. Defaults to hirundo/__init__.py"
+        required: false
+        type: string
   pull_request:
     types: [closed]
     paths:
@@ -9,11 +23,11 @@ on:
 jobs:
   push_to_pypi:
     name: Upload release to PyPI
-    if: ${{ github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'test')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'test'))) }}
     runs-on: ubuntu-latest
     environment:
-      name: ${{ contains(github.event.pull_request.labels.*.name, 'release') && 'pypi' || 'testpypi' }}
-      url: ${{ contains(github.event.pull_request.labels.*.name, 'release') && 'https://pypi.org/p/hirundo' || 'https://test.pypi.org/p/hirundo' }}
+      name: ${{ ((github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release'))) && 'pypi' || 'testpypi' }}
+      url: ${{ ((github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release'))) && 'https://pypi.org/p/hirundo' || 'https://test.pypi.org/p/hirundo' }}
     permissions:
       contents: write  # Used to push tag with release
       pull-requests: read  # Used to create and merge PR with release
@@ -21,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
       - uses: astral-sh/setup-uv@v7
       - name: Push tag with release
         env:
@@ -29,18 +43,46 @@ jobs:
         run: |
           git config user.name "GitHub Actions [release-bot]"
           git config user.email "github-actions@hirundo.io"
-          git pull origin ${{ github.event.pull_request.base.ref }}
-
-          # Write PR body literally (no interpolation or command substitution)
-          cat > .tagmsg.txt <<-'EOF'
-          ${{ github.event.pull_request.body }}
-          EOF
+          REF_NAME="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            REF_NAME="${{ github.event.pull_request.base.ref }}"
+          elif [ "$REF_NAME" != "main" ]; then
+            echo "Manual release recovery must be run from main, not $REF_NAME"
+            exit 1
+          fi
+          git pull origin "$REF_NAME"
 
           VERSION=$(python -c "import re; content=open('hirundo/__init__.py').read(); print(re.search(r'__version__ = [\"\\'](.*?)[\"\\']', content).group(1))")
+          EXPECTED_VERSION="${{ inputs.version }}"
+          if [ -n "$EXPECTED_VERSION" ] && [ "$EXPECTED_VERSION" != "$VERSION" ]; then
+            echo "Expected version $EXPECTED_VERSION but hirundo/__init__.py contains $VERSION"
+            exit 1
+          fi
+
           TAG_NAME="v${VERSION}"
 
-          git tag -a "${TAG_NAME}" -F .tagmsg.txt
-          git push origin "${TAG_NAME}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && git ls-remote --exit-code --tags origin "$TAG_NAME" >/dev/null; then
+            git fetch --force origin "refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}"
+            TAG_COMMIT=$(git rev-list -n 1 "$TAG_NAME")
+            HEAD_COMMIT=$(git rev-parse HEAD)
+            if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
+              echo "Tag $TAG_NAME points to $TAG_COMMIT, but checked out $HEAD_COMMIT"
+              exit 1
+            fi
+            echo "Reusing existing tag $TAG_NAME"
+          else
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              # Write PR body literally (no interpolation or command substitution)
+              cat > .tagmsg.txt <<-'EOF'
+          ${{ github.event.pull_request.body }}
+          EOF
+            else
+              echo "Release ${TAG_NAME}" > .tagmsg.txt
+            fi
+
+            git tag -a "${TAG_NAME}" -F .tagmsg.txt
+            git push origin "${TAG_NAME}"
+          fi
       - name: Install dependencies & build package
         run: |
           uv venv
@@ -57,9 +99,9 @@ jobs:
           password: ${{ secrets.TESTPYPI_APIKEY }}
       - name: Publish package distributions to TestPyPI (GitHub Actions)
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'test') }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test')) }}
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release')) }}

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   deploy-docs:
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'test'))) }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -34,7 +35,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all tags and branches
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        timeout-minutes: 5
+        timeout-minutes: 30
         env:
           SLEEP: 15
         run: |

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -1,6 +1,12 @@
 name: Deploy Sphinx docs to GitHub Pages
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Expected version. Defaults to hirundo/__init__.py"
+        required: false
+        type: string
   pull_request:
     types: [closed]
     paths:
@@ -23,7 +29,7 @@ concurrency:
 
 jobs:
   deploy-docs:
-    if: ${{ github.event_name == 'push' || (github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'test'))) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'test'))) }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -32,6 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
           fetch-depth: 0 # Fetch all history for all tags and branches
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
@@ -39,6 +46,11 @@ jobs:
         env:
           SLEEP: 15
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Manual docs deployment must be run from main, not ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
           uv venv
           source .venv/bin/activate
           uv sync --only-group docs --no-install-project
@@ -51,6 +63,11 @@ jobs:
           echo "Using version: $VERSION"
           if [ "$VERSION" = "unknown" ] || [ -z "$VERSION" ]; then
             echo "Error: Could not extract version from hirundo/__init__.py (file may be missing, unreadable, or version format is invalid)"
+            exit 1
+          fi
+          EXPECTED_VERSION="${{ inputs.version }}"
+          if [ -n "$EXPECTED_VERSION" ] && [ "$EXPECTED_VERSION" != "$VERSION" ]; then
+            echo "Expected version $EXPECTED_VERSION but hirundo/__init__.py contains $VERSION"
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"


### PR DESCRIPTION
# User description
## Summary
- Add `workflow_dispatch` to `deploy-to-pypi.yaml` so an already-merged version can be published manually from `main`.
- Keep the existing label-gated `pull_request` release behavior intact.
- Guard docs deploy with the same `release` / `test` label condition so unlabeled version bumps do not wait for packages that will never publish.
- Increase the docs PyPI wait timeout to 30 minutes for normal release propagation.

## Validation
- Parsed `deploy-to-pypi.yaml` and `update-docs.yaml` with PyYAML.
- Checked the edited shell snippets with `bash -n` after substituting GitHub expressions.
- `git diff --check`

## Recovery after merge
1. Run workflow `Push new release of the package to PyPI` manually on `main`.
2. Inputs: `target=pypi`, `version=0.3.0`.
3. After publish succeeds, rerun the failed docs deployment.

Linear: SDK-121
Related: SDK-120

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add manual dispatch inputs and validation to <code>deploy-to-pypi</code> so merged <code>main</code> versions can be republished without altering the existing label gating. Guard <code>update-docs</code> with release/test labels, enforce expected versions, and lengthen the PyPI wait loop to prevent docs from waiting on unreleased builds.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/272?tool=ast&topic=Manual+release+publish>Manual release publish</a>
        </td><td>Enable manual release publishing by adding dispatch inputs and version/tag guards to <code>deploy-to-pypi</code>, while keeping the merge-label gating intact.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/deploy-to-pypi.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Add manual release rec...</td><td>July 05, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Migrate to `uv` for de...</td><td>February 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/hirundo-python-sdk/272?tool=ast&topic=Docs+deployment+guard>Docs deployment guard</a>
        </td><td>Guard doc deployment with the same release/test label checks, validate expected versions, and extend the package-install wait to avoid hanging when no publish occurs.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/update-docs.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Add manual docs recove...</td><td>July 06, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Migrate to `uv` for de...</td><td>February 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/hirundo-python-sdk/272?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>